### PR TITLE
Add offset resume capability

### DIFF
--- a/ftp_test.go
+++ b/ftp_test.go
@@ -12,7 +12,14 @@ var (
 	password = os.Getenv("ZFTP_PASSWORD")
 )
 
+func requireEnv(t *testing.T) {
+	if hostname == "" || username == "" || password == "" {
+		t.Skip("FTP server credentials not configured")
+	}
+}
+
 func TestOpen(t *testing.T) {
+	requireEnv(t)
 
 	s, err := zftp.Open(hostname)
 	if err != nil {

--- a/get_test.go
+++ b/get_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestFTPSession_Get(t *testing.T) {
+	requireEnv(t)
 
 	s, err := zftp.Open(hostname)
 	if err != nil {

--- a/jes_test.go
+++ b/jes_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestSubmitJCL(t *testing.T) {
+	requireEnv(t)
 	// Create a new FTP session
 	s, err := zftp.Open(hostname)
 	if err != nil {
@@ -118,6 +119,7 @@ HELLO, WORLD!
 }
 
 func TestSubmitLISTDS(t *testing.T) {
+	requireEnv(t)
 	// Create a new FTP session
 	s, err := zftp.Open(hostname)
 	if err != nil {
@@ -159,6 +161,7 @@ func TestSubmitLISTDS(t *testing.T) {
 
 func TestSubmitDITTO(t *testing.T) {
 	//log.SetLevel(log.All)
+	requireEnv(t)
 	// Create a new FTP session
 	s, err := zftp.Open(hostname)
 	if err != nil {

--- a/lists_test.go
+++ b/lists_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestFTPSession_List(t *testing.T) {
+	requireEnv(t)
 	s, err := zftp.Open(hostname)
 	if err != nil {
 		t.Fatal(err)

--- a/put_test.go
+++ b/put_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestFTPSession_Put(t *testing.T) {
+	requireEnv(t)
 
 	s, err := zftp.Open(hostname)
 	if err != nil {

--- a/xstat_test.go
+++ b/xstat_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestFTPSession_StatusOf(t *testing.T) {
+	requireEnv(t)
 	// Create a new FTP session
 	s, err := zftp.Open(hostname)
 	if err != nil {


### PR DESCRIPTION
## Summary
- support restarting transfers with REST
- add `GetAt` and `PutAt` helper methods
- implement `StoreIOAt` and `RetrieveIOAt` for offset operations
- skip integration tests when FTP credentials are missing

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_683a786c88f88325a047e1254baf6987