### PR TITLE
Expose Conn interface

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -42,6 +42,8 @@ Here are some of the most important functions provided by the zftp package:
 - `(*FTPSession) ListDatasets(remotePath string) ([]hfs.Dataset, error)`: List z/OS datasets at the specified remote path, including dataset attributes.
 
 - `(*FTPSession) GetAndGzip(remoteFile, localFile string, transferType TransferType) error`: Retrieve a file from the FTP server, compress it using gzip format, and store it locally in a single step.
+- `(*FTPSession) Conn() net.Conn`: Retrieve the underlying connection so you can
+  apply custom options such as TCP keep-alives.
 
 Refer to the [GoDoc](https://pkg.go.dev/gopkg.in/ro-ag/zftp.v0) for detailed documentation and more functions provided by the package.
 

--- a/ftp.go
+++ b/ftp.go
@@ -73,6 +73,12 @@ func (s *FTPSession) SetVerbose(level LogLevel) {
 	log.SetLevel(log.Level(level))
 }
 
+// Conn exposes the underlying network connection used by the session.
+// This allows the caller to apply custom options such as TCP keep alive.
+func (s *FTPSession) Conn() net.Conn {
+	return s.conn
+}
+
 // AuthTLS sends the AUTH TLS command to the FTP server and sets up the TLS connection
 func (s *FTPSession) AuthTLS(tlsConfig *tls.Config) error {
 	s.mu.Lock()


### PR DESCRIPTION
## Summary
- add `Conn` method to `FTPSession` for retrieving the underlying network connection
- document the method in README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685637eeb4148325925734455ed42c7a