### PR TITLE
Support dial options for Open

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -29,7 +29,7 @@ go get gopkg.in/ro-ag/zftp.v1
 
 Here are some of the most important functions provided by the zftp package:
 
-- `Open(hostname string) (*FTPSession, error)`: Open an FTP session to the specified hostname, returning a session instance for further operations.
+- `Open(hostname string, opts ...Option) (*FTPSession, error)`: Open an FTP session to the specified hostname. Optional `Option` values allow you to configure timeouts or TCP keep-alives for the underlying connections.
 
 - `(*FTPSession) Login(username, password string) error`: Log in to the FTP server using the provided username and password.
 
@@ -55,13 +55,14 @@ Here's an example that demonstrates the basic usage of the zftp package:
 package main
 
 import (
-	"fmt"
-	"gopkg.in/ro-ag/zftp.v0"
+        "fmt"
+        "time"
+        "gopkg.in/ro-ag/zftp.v0"
 )
 
 func main() {
-	// Open an FTP session to the mainframe server
-	s, err := zftp.Open("example.com")
+        // Open an FTP session to the mainframe server with a 30s timeout
+        s, err := zftp.Open("example.com", zftp.WithTimeout(30*time.Second))
 	if err != nil {
 		fmt.Println("Failed to open FTP session:", err)
 		return

--- a/options.go
+++ b/options.go
@@ -1,0 +1,30 @@
+package zftp
+
+import "time"
+
+// Option configures behavior for Open and passive connections.
+type Option func(*dialOptions)
+
+// dialOptions holds configuration for network dialing.
+type dialOptions struct {
+	DialTimeout     time.Duration
+	KeepAlivePeriod time.Duration
+}
+
+// apply runs the option functions on a dialOptions struct.
+func (o *dialOptions) apply(opts []Option) {
+	for _, fn := range opts {
+		fn(o)
+	}
+}
+
+// WithTimeout sets the timeout for establishing connections.
+func WithTimeout(d time.Duration) Option {
+	return func(o *dialOptions) { o.DialTimeout = d }
+}
+
+// WithKeepAlive sets TCP keep-alive with the given period.
+// A zero duration disables keep-alives.
+func WithKeepAlive(d time.Duration) Option {
+	return func(o *dialOptions) { o.KeepAlivePeriod = d }
+}


### PR DESCRIPTION
## Summary
- add `Option` functional configuration for network connections
- allow `Open` to receive options like keep-alive and timeout
- apply dial options to passive data connections
- document new options in README

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68567813af248325b33387115c91035b