### PR TITLE
fix: stop tracking the accidentally-committed cli/cli binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,19 @@ venv/
 dummy/
 .vscode/
 .claude/
+
+# Compiled CLI binaries / build output
+/cli/cli
+/cli/zftp
+/zftp
+*.exe
+
+# Test and coverage artifacts
+*.test
+*.out
+coverage.txt
+coverage.html
+
+# Go workspace files
+go.work
+go.work.sum


### PR DESCRIPTION
The ZM09 CLI skeleton accidentally committed the compiled `cli/cli` binary (a stray `go build` artifact staged by `git add cli/`), which merged into main via #17. This removes it from version control and extends `.gitignore` so the CLI binaries and Go build/test artifacts are never tracked again. No source or behavior change; build stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)