### PR TITLE
fix: concurrency-safe command channel + context-timeout desync (ZH01/ZH08)

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -4,49 +4,80 @@ package zftp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"gopkg.in/ro-ag/zftp.v2/internal/log"
 	"gopkg.in/ro-ag/zftp.v2/internal/utils"
 	"strings"
+	"time"
 )
 
-// SendCommandWithContext sends a command to the FTP server and expects a specific return code.
-// The context allows for cancellation or timeouts.
+// SendCommandWithContext sends a command to the FTP server and expects a specific
+// return code. The context allows for cancellation or timeouts.
+//
+// The whole round-trip (write + reply) is serialized on the session mutex so the
+// control stream is never read or written by two goroutines at once, making
+// *FTPSession safe to share across goroutines.
 func (s *FTPSession) SendCommandWithContext(ctx context.Context, expect ReturnCode, command string, a ...string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.sendLocked(ctx, expect, command, a...)
+}
 
-	var (
-		errChan     = make(chan error, 1)
-		respChan    = make(chan string, 1)
-		fullCommand = parseCommand(command, a...)
-	)
-
-	go func() {
-		// log has already been printed in parseCommand
-		_, err := s.conn.Write(fullCommand)
-		if err != nil {
-			log.Commandf("error %s", err)
-			errChan <- err
-			return
-		}
-
-		msg, err := expect.check(s.reader)
-		if err != nil {
-			log.Serverf("error %s", err)
-			errChan <- err
-			return
-		}
-
-		respChan <- msg
-	}()
-
-	select {
-	case <-ctx.Done():
-		return "", ctx.Err()
-	case err := <-errChan:
-		return "", err
-	case resp := <-respChan:
-		return resp, nil
+// sendLocked performs a single control-connection round-trip. The caller must
+// hold s.mu.
+//
+// Cancellation is honored by pushing the context deadline onto the connection and
+// doing the write/read inline (no spawned goroutine). FTP has no in-band way to
+// resynchronize a control stream once a reply is partially read, so any I/O-level
+// failure — a deadline firing, EOF, or a reset — leaves the stream unrecoverable:
+// the session is closed so later commands fail fast instead of reading a stale
+// reply. A complete-but-unexpected reply (a *ReturnError) keeps the stream in
+// sync and does not close the session.
+func (s *FTPSession) sendLocked(ctx context.Context, expect ReturnCode, command string, a ...string) (string, error) {
+	if s.isClosed.Load() {
+		return "", fmt.Errorf("zftp: cannot send %s: session is closed", strings.ToUpper(strings.TrimSpace(command)))
 	}
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
+	conn, reader := s.conn, s.reader
+	fullCommand := parseCommand(command, a...)
+
+	if dl, ok := ctx.Deadline(); ok {
+		if err := conn.SetDeadline(dl); err != nil {
+			return "", err
+		}
+		defer func() { _ = conn.SetDeadline(time.Time{}) }()
+	}
+
+	// log has already been printed in parseCommand
+	if _, err := conn.Write(fullCommand); err != nil {
+		log.Commandf("error %s", err)
+		s.closeLocked()
+		return "", fmt.Errorf("zftp: control connection write failed, session closed: %w", err)
+	}
+
+	msg, err := expect.check(reader)
+	if err != nil {
+		log.Serverf("error %s", err)
+		var re *ReturnError
+		if errors.As(err, &re) {
+			// Reply read in full but with an unexpected (yet valid) FTP code; the
+			// control stream is still in sync, so keep the session usable.
+			return msg, err
+		}
+		// I/O-level failure: the control stream is desynchronized for good.
+		s.closeLocked()
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return "", fmt.Errorf("zftp: command %s aborted (%w), session closed: %w",
+				strings.ToUpper(strings.TrimSpace(command)), ctxErr, err)
+		}
+		return "", fmt.Errorf("zftp: control connection error, session closed: %w", err)
+	}
+
+	return msg, nil
 }
 
 // parseCommand parses a command and its arguments into a byte slice.
@@ -99,6 +130,12 @@ func (s *FTPSession) checkLast(expect ReturnCode) (string, error) {
 
 	if err != nil {
 		log.Serverf("[res|error] %s", err)
+		var re *ReturnError
+		if !errors.As(err, &re) {
+			// I/O-level failure on the post-transfer reply read: like sendLocked,
+			// the control stream is desynchronized for good, so close the session.
+			s.closeLocked()
+		}
 		return "", err
 	}
 
@@ -107,8 +144,11 @@ func (s *FTPSession) checkLast(expect ReturnCode) (string, error) {
 
 // System get the system type of the FTP server. will panic
 func (s *FTPSession) System() string {
-	if s.system != "" {
-		return s.system
+	s.mu.Lock()
+	sys := s.system
+	s.mu.Unlock()
+	if sys != "" {
+		return sys
 	}
 
 	system, err := s.SendCommand(CodeSysType, "SYST")

--- a/codes.go
+++ b/codes.go
@@ -86,8 +86,16 @@ func (code ReturnCode) check(reader *bufio.Reader) (msg string, err error) {
 	for {
 		line, isPrefix, err := reader.ReadLine()
 		if err != nil {
-			// If ReadLine returns an io.EOF error, we return what we have
 			if err == io.EOF {
+				// EOF before any complete reply line means the peer closed the
+				// control stream mid-reply: an unrecoverable I/O failure, not a
+				// valid (if unexpected) FTP reply. Surface it as a plain error so
+				// callers close the desynchronized session instead of mistaking it
+				// for a ReturnError. If a complete reply was already read, fall
+				// through and let the code-mismatch logic below report it.
+				if receivedCode == 0 {
+					return response.String(), io.ErrUnexpectedEOF
+				}
 				break
 			}
 			return "", err

--- a/concurrency_test.go
+++ b/concurrency_test.go
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package zftp_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	zftp "gopkg.in/ro-ag/zftp.v2"
+)
+
+// runWithTimeout runs fn in a goroutine and fails the test if it does not return
+// within d. It turns a deadlock or a desynchronized control stream (which would
+// otherwise hang the whole package until the global -timeout) into a fast, clear
+// failure.
+func runWithTimeout(t *testing.T, d time.Duration, fn func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fn()
+	}()
+	select {
+	case <-done:
+	case <-time.After(d):
+		t.Fatalf("operation did not complete within %s (possible deadlock or stream desync)", d)
+	}
+}
+
+// TestSession_ConcurrentCommandsAndClose_RaceFree shares one *FTPSession across
+// many goroutines issuing control round-trips, passive negotiations and transfer
+// type changes while another goroutine closes the session. It must run cleanly
+// under `go test -race`: every command-issuing path and Close has to serialize on
+// the session mutex, and mutable fields (the control reader and currType) must
+// not be touched concurrently.
+func TestSession_ConcurrentCommandsAndClose_RaceFree(t *testing.T) {
+	s, _ := dialMock(t)
+
+	runWithTimeout(t, 10*time.Second, func() {
+		var wg sync.WaitGroup
+
+		// Concurrent control round-trips: each reads the shared control reader.
+		for i := 0; i < 8; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_, _ = s.SendCommand(zftp.CodeCmdOK, "NOOP")
+			}()
+		}
+
+		// Concurrent passive-mode negotiations (PASV round-trip + parse).
+		for i := 0; i < 4; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_, _ = s.SetPassiveMode()
+			}()
+		}
+
+		// Concurrent transfer-type writes (exercise the currType field).
+		for i := 0; i < 4; i++ {
+			typ := zftp.TypeAscii
+			if i%2 == 1 {
+				typ = zftp.TypeBinary
+			}
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_ = s.SetType(typ)
+			}()
+		}
+
+		// A concurrent Close must not race the in-flight commands.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = s.Close()
+		}()
+
+		wg.Wait()
+	})
+}
+
+// TestSendCommandWithContext_TimeoutClosesSession reproduces the timeout-desync
+// bug: when the server withholds a reply and the context deadline fires, the call
+// must abort its own I/O, report an error, and mark the session closed so the
+// control stream cannot be read one reply ahead by a later command. A subsequent
+// command must then fail fast rather than block or consume a stale reply.
+func TestSendCommandWithContext_TimeoutClosesSession(t *testing.T) {
+	s, srv := dialMock(t)
+	srv.Withhold("STAT") // the server receives STAT but never replies
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	if _, err := s.SendCommandWithContext(ctx, zftp.CodeSysStatus, "STAT"); err == nil {
+		t.Fatal("SendCommandWithContext: want a timeout error, got nil")
+	}
+
+	if !s.IsClosed() {
+		t.Fatal("session must be closed after a control-stream timeout")
+	}
+
+	// The desync this guards against: a later command must not block on, or read,
+	// the stale reply left behind by the timed-out command.
+	runWithTimeout(t, 2*time.Second, func() {
+		if _, err := s.SendCommand(zftp.CodeCmdOK, "NOOP"); err == nil {
+			t.Error("SendCommand on a closed session: want an error, got nil")
+		}
+	})
+}
+
+// TestClose_UnblocksStalledCommand guards against a deadlock regression: a
+// SendCommand with no deadline blocks reading the reply while holding the session
+// mutex. If a peer goes silent, a concurrent Close must still be able to tear the
+// session down (by interrupting the in-flight read) instead of starving forever
+// on the mutex.
+func TestClose_UnblocksStalledCommand(t *testing.T) {
+	s, srv := dialMock(t)
+	srv.Withhold("STAT") // STAT is received but never answered
+
+	cmdDone := make(chan error, 1)
+	go func() {
+		_, err := s.SendCommand(zftp.CodeSysStatus, "STAT") // no deadline: blocks under s.mu
+		cmdDone <- err
+	}()
+	time.Sleep(150 * time.Millisecond) // let the command acquire the mutex and block on the read
+
+	// Close must not hang behind the stalled command.
+	runWithTimeout(t, 3*time.Second, func() { _ = s.Close() })
+
+	// And the stalled command must be released (with an error), not leaked.
+	select {
+	case err := <-cmdDone:
+		if err == nil {
+			t.Error("stalled SendCommand: want an error after Close, got nil")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("stalled SendCommand was not unblocked by Close")
+	}
+}
+
+// TestSendCommand_PeerCloseClosesSession reproduces the EOF-misclassification
+// bug: when the peer drops the control connection instead of replying, the read
+// hits EOF. That is an unrecoverable I/O failure (not a valid FTP reply), so the
+// session must be marked closed — not left open to read garbage on the next call.
+func TestSendCommand_PeerCloseClosesSession(t *testing.T) {
+	s, srv := dialMock(t)
+	srv.Hangup("STAT") // server drops the control connection on STAT
+
+	if _, err := s.SendCommand(zftp.CodeSysStatus, "STAT"); err == nil {
+		t.Fatal("SendCommand: want an error when the peer closes the control connection, got nil")
+	}
+	if !s.IsClosed() {
+		t.Fatal("session must be closed after a control-connection EOF")
+	}
+}
+
+// TestList_ControlDropClosesSession covers the other control-stream reader: the
+// post-transfer reply read in checkLast. If the peer drops the control connection
+// after the data but before the closing reply, checkLast hits EOF and must close
+// the session, since the stream is desynchronized for any later command.
+func TestList_ControlDropClosesSession(t *testing.T) {
+	s, srv := dialMock(t)
+	srv.DataFor("LIST", "", "FA00FF 3390 PS 'ABCD.EF.SEQ'\r\n")
+	srv.DropControlAfterData("LIST") // data is delivered, then the control conn is dropped (no 250)
+
+	if _, err := s.List("ABCD.EF.*"); err == nil {
+		t.Fatal("List: want an error when the closing reply never arrives, got nil")
+	}
+	if !s.IsClosed() {
+		t.Fatal("session must be closed after the post-transfer reply read hits EOF")
+	}
+}
+
+// TestSession_ConcurrentListAndClose_NoPanic runs a passive LIST whose data
+// scan is in flight while the session is closed from another goroutine. Closing
+// must interrupt the data scan promptly and must not panic or deadlock.
+func TestSession_ConcurrentListAndClose_NoPanic(t *testing.T) {
+	s, srv := dialMock(t)
+	// A sizable listing so the data scan is still draining when Close lands.
+	var listing string
+	for i := 0; i < 500; i++ {
+		listing += "FA00FF 3390   2023/06/02  1  360  VB    8004 27998  PS  'ABCD.EF.SEQ'\r\n"
+	}
+	srv.DataFor("LIST", "", listing)
+
+	runWithTimeout(t, 10*time.Second, func() {
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = s.List("ABCD.EF.*")
+		}()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = s.Close()
+		}()
+		wg.Wait()
+	})
+}

--- a/ftp.go
+++ b/ftp.go
@@ -18,14 +18,16 @@ import (
 	"sync"
 	"sync/atomic"
 	"syscall"
+	"time"
 )
 
 // FTPSession represents an FTP session
 type FTPSession struct {
 	conn        net.Conn
+	rawConn     net.Conn // underlying socket, never swapped on TLS upgrade; lets Close interrupt a blocked control read
 	system      string
 	user        string
-	currType    TransferType
+	currType    atomic.Uint32 // current TransferType; atomic so transfers can read it lock-free
 	jobPrefix   *regexp.Regexp
 	isClosed    atomic.Bool
 	reader      *bufio.Reader
@@ -94,6 +96,7 @@ func dialControl(server string, cfg dialOptions) (net.Conn, error) {
 func newSession(conn net.Conn, cfg dialOptions) *FTPSession {
 	return &FTPSession{
 		conn:      conn,
+		rawConn:   conn,
 		reader:    bufio.NewReader(conn),
 		dialCfg:   cfg,
 		jobPrefix: regexp.MustCompile(`(JOB\d{5})`),
@@ -133,7 +136,9 @@ func (s *FTPSession) AuthTLS(tlsConfig *tls.Config) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	_, err := s.SendCommand(CodeSecurityOk, "AUTH", "TLS")
+	// Already holding s.mu: use sendLocked to avoid re-entrant deadlock, and keep
+	// the AUTH negotiation and the conn/reader swap atomic against other commands.
+	_, err := s.sendLocked(context.Background(), CodeSecurityOk, "AUTH", "TLS")
 	if err != nil {
 		return err
 	}
@@ -145,13 +150,13 @@ func (s *FTPSession) AuthTLS(tlsConfig *tls.Config) error {
 	s.reader = bufio.NewReader(s.conn)
 
 	// Protection Buffer Size
-	_, err = s.SendCommand(CodeCmdOK, "PBSZ", "0")
+	_, err = s.sendLocked(context.Background(), CodeCmdOK, "PBSZ", "0")
 	if err != nil {
 		return err
 	}
 
 	// data Channel Protection Level
-	_, err = s.SendCommand(CodeCmdOK, "PROT", "P")
+	_, err = s.sendLocked(context.Background(), CodeCmdOK, "PROT", "P")
 	if err != nil {
 		return err
 	}
@@ -159,32 +164,55 @@ func (s *FTPSession) AuthTLS(tlsConfig *tls.Config) error {
 	return nil
 }
 
-// Close closes all connections to the FTP server
+// Close closes all connections to the FTP server. It is idempotent and safe to
+// call concurrently with in-flight commands: Close and the command path both take
+// the session mutex, so a command in progress finishes before the connection is
+// torn down (and a command that starts after Close fails cleanly).
 func (s *FTPSession) Close() error {
+	// Interrupt any control read currently blocked under s.mu so its goroutine
+	// returns and releases the lock; otherwise Close would block forever behind a
+	// command stalled on a silent peer. rawConn is the underlying socket (never
+	// swapped on a TLS upgrade), so this interrupts plaintext and TLS reads alike.
+	// It is safe to touch without the lock: rawConn is set once at construction.
+	_ = s.rawConn.SetDeadline(time.Now())
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	// Close all data connections
+	return s.closeLocked()
+}
+
+// closeLocked tears down the control connection and every data connection. It is
+// idempotent. The caller must hold s.mu. It is also invoked from the send path
+// when an I/O error leaves the control stream unrecoverable.
+func (s *FTPSession) closeLocked() error {
+	if s.isClosed.Swap(true) {
+		return nil
+	}
+
+	// Close all data connections.
 	s.dataConns.Range(func(name, conn any) bool {
 		child := conn.(*childConnection)
 		log.Debugf("closing child net connection %s", child.RemoteAddr())
-		err := child.Close()
-		if err != nil {
+		if err := child.Close(); err != nil {
 			log.Warningf("Error closing child net connection %s: %s", child.RemoteAddr(), err)
 		}
 		return true
 	})
 
-	// Send QUIT command and close main connection
-
 	log.Debugf("closing session connection %s", s.conn.RemoteAddr())
-
-	err := s.conn.Close()
-	if err != nil {
+	if err := s.conn.Close(); err != nil {
 		log.Warningf("Error closing session connection: %s", err)
 		return err
 	}
-	s.isClosed.Store(true)
 	return nil
+}
+
+// IsClosed reports whether the session has been closed — either explicitly via
+// Close or implicitly after an unrecoverable control-connection error (for
+// example a context timeout that aborts an in-flight command). A closed session
+// rejects further commands.
+func (s *FTPSession) IsClosed() bool {
+	return s.isClosed.Load()
 }
 
 // Login sends the USER and PASS commands to the FTP server
@@ -194,41 +222,44 @@ func (s *FTPSession) Login(user, pass string) error {
 
 	s.user = strings.ToUpper(user)
 
-	_, err := s.SendCommand(CodeNeedPwd, "USER", user)
+	// The whole login handshake runs under s.mu, so every step uses the locked
+	// helpers (sendLocked / setTypeLocked / setStatusOfLocked) to avoid the
+	// re-entrant deadlock a sync.Mutex would otherwise cause.
+	_, err := s.sendLocked(context.Background(), CodeNeedPwd, "USER", user)
 	if err != nil {
 		return err
 	}
 
-	_, err = s.SendCommand(CodeLoggedInProceed, "PASS", pass)
+	_, err = s.sendLocked(context.Background(), CodeLoggedInProceed, "PASS", pass)
 	if err != nil {
 		return err
 	}
 	// set passive mode
-	_, err = s.SendCommand(CodeEnteringPassiveMode, "PASV")
+	_, err = s.sendLocked(context.Background(), CodeEnteringPassiveMode, "PASV")
 	if err != nil {
 		return err
 	}
 
 	/* Set default type to Image or Binary */
-	err = s.SetType(TypeImage)
+	err = s.setTypeLocked(TypeImage)
 	if err != nil {
 		return err
 	}
 
 	/* Indicate mainframe set End of line default per system */
-	err = s.SetStatusOf().SBSendEol(eol.System)
+	err = s.setStatusOfLocked().SBSendEol(eol.System)
 	if err != nil {
 		return err
 	}
 
 	/* Indicate mainframe set End of line default per system */
-	err = s.SetStatusOf().MBSendEol(eol.System)
+	err = s.setStatusOfLocked().MBSendEol(eol.System)
 	if err != nil {
 		return err
 	}
 
 	/* Check */
-	syt, err := s.SendCommand(CodeSysType, "SYST")
+	syt, err := s.sendLocked(context.Background(), CodeSysType, "SYST")
 	if err != nil {
 		return err
 	}
@@ -244,5 +275,7 @@ func (s *FTPSession) Login(user, pass string) error {
 
 // GetUser returns the current username
 func (s *FTPSession) GetUser() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.user
 }

--- a/internal/mockzos/script.go
+++ b/internal/mockzos/script.go
@@ -40,6 +40,68 @@ func (s *Server) DataFor(verb, arg, payload string) {
 	s.dataByLine[verb+" "+strings.TrimSpace(arg)] = payload
 }
 
+// Withhold makes the server consume the matching command without ever sending a
+// reply, modeling a hung or unresponsive control connection. The match key may be
+// a full command line ("XSTA (BLOCKSIze") or just a verb ("STAT"), like Script.
+// It lets tests drive the client's context-timeout / cancellation paths.
+//
+//	srv.Withhold("STAT") // the next STAT receives no reply
+func (s *Server) Withhold(command string) {
+	key := strings.ToUpper(strings.TrimSpace(command))
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.withheld[key] = true
+}
+
+func (s *Server) isWithheld(line, verb string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.withheld[strings.ToUpper(strings.TrimSpace(line))] {
+		return true
+	}
+	return s.withheld[verb]
+}
+
+// Hangup makes the server drop the control connection (without replying) when it
+// receives the matching command, modeling a peer that closes the control stream
+// — the client's reply read then sees EOF. The match key may be a full command
+// line or just a verb, like Script.
+//
+//	srv.Hangup("STAT") // the next STAT closes the control connection
+func (s *Server) Hangup(command string) {
+	key := strings.ToUpper(strings.TrimSpace(command))
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.hangup[key] = true
+}
+
+func (s *Server) isHangup(line, verb string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.hangup[strings.ToUpper(strings.TrimSpace(line))] {
+		return true
+	}
+	return s.hangup[verb]
+}
+
+// DropControlAfterData makes a download (LIST/NLST/RETR) deliver its data and
+// then drop the control connection instead of sending the closing 250 reply, so
+// the client's post-transfer reply read hits EOF. The key is a verb.
+//
+//	srv.DropControlAfterData("LIST")
+func (s *Server) DropControlAfterData(verb string) {
+	key := strings.ToUpper(strings.TrimSpace(verb))
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.dropAfterData[key] = true
+}
+
+func (s *Server) isDropAfterData(verb string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.dropAfterData[verb]
+}
+
 // Commands returns a copy of every command line the server has received, in
 // order, so tests can assert on the exact control sequence (e.g. TYPE/SITE/REST).
 func (s *Server) Commands() []string {

--- a/internal/mockzos/server.go
+++ b/internal/mockzos/server.go
@@ -33,13 +33,16 @@ type Server struct {
 	closed atomic.Bool
 	wg     sync.WaitGroup
 
-	mu          sync.Mutex
-	lineScripts map[string][]string // full command line (upper) -> raw reply lines
-	verbScripts map[string][]string // verb (upper) -> raw reply lines
-	dataByLine  map[string]string   // full command line (upper) -> payload to send
-	dataByVerb  map[string]string   // verb (upper) -> payload to send
-	stored      map[string][]byte   // STOR arg (upper) -> captured payload
-	received    []string            // every command line received, in order
+	mu            sync.Mutex
+	lineScripts   map[string][]string // full command line (upper) -> raw reply lines
+	verbScripts   map[string][]string // verb (upper) -> raw reply lines
+	dataByLine    map[string]string   // full command line (upper) -> payload to send
+	dataByVerb    map[string]string   // verb (upper) -> payload to send
+	stored        map[string][]byte   // STOR arg (upper) -> captured payload
+	withheld      map[string]bool     // full line or verb (upper) -> swallow without replying
+	hangup        map[string]bool     // full line or verb (upper) -> drop the control conn without replying
+	dropAfterData map[string]bool     // download verb (upper) -> drop control after data, before the closing reply
+	received      []string            // every command line received, in order
 }
 
 // New starts a Server on 127.0.0.1:0 and registers cleanup with the test.
@@ -50,13 +53,16 @@ func New(tb testing.TB) *Server {
 		tb.Fatalf("mockzos listen: %v", err)
 	}
 	s := &Server{
-		tb:          tb,
-		ln:          ln,
-		lineScripts: map[string][]string{},
-		verbScripts: map[string][]string{},
-		dataByLine:  map[string]string{},
-		dataByVerb:  map[string]string{},
-		stored:      map[string][]byte{},
+		tb:            tb,
+		ln:            ln,
+		lineScripts:   map[string][]string{},
+		verbScripts:   map[string][]string{},
+		dataByLine:    map[string]string{},
+		dataByVerb:    map[string]string{},
+		stored:        map[string][]byte{},
+		withheld:      map[string]bool{},
+		hangup:        map[string]bool{},
+		dropAfterData: map[string]bool{},
 	}
 	s.wg.Add(1)
 	go s.serve()
@@ -128,6 +134,17 @@ func (s *Server) handle(conn net.Conn) {
 // dispatch handles a single command. It returns true when the connection should
 // close (QUIT).
 func (s *Server) dispatch(sess *session, line, verb, arg string) bool {
+	// A withheld command is consumed without any reply, modeling a hung control
+	// connection so the client's timeout/cancel paths can be exercised. The
+	// connection stays open; the client is expected to give up and close it.
+	if s.isWithheld(line, verb) {
+		return false
+	}
+	// A hung-up command drops the control connection with no reply, modeling a
+	// peer that closes the control stream (EOF) instead of answering.
+	if s.isHangup(line, verb) {
+		return true
+	}
 	// Explicit scripted replies take precedence over defaults.
 	if reply, ok := s.scriptFor(line, verb); ok {
 		writeLines(sess.conn, reply)
@@ -204,6 +221,12 @@ func (s *Server) handleDownload(sess *session, line, verb, arg string) {
 	writeLines(sess.conn, []string{"125 data connection already open; transfer starting"})
 	_, _ = dc.Write([]byte(payload))
 	_ = dc.Close()
+	// Optionally drop the control connection after the data has been delivered but
+	// before the closing reply, so the client's post-transfer reply read hits EOF.
+	if s.isDropAfterData(verb) {
+		_ = sess.conn.Close()
+		return
+	}
 	writeLines(sess.conn, []string{"250 transfer completed successfully"})
 }
 

--- a/lists.go
+++ b/lists.go
@@ -24,7 +24,7 @@ func (s *FTPSession) anyList(cmd, expression string) ([]string, string, error) {
 		log.Panicf("invalid command: %s", cmd)
 	}
 
-	current := s.currType
+	current := s.currentType()
 
 	if current != TypeAscii {
 		if err := s.SetType(TypeAscii); err != nil {

--- a/passive.go
+++ b/passive.go
@@ -100,33 +100,34 @@ func (c *childConnection) Write(b []byte) (n int, err error) {
 // It updates the isClosed flag and deletes the connection from the maps.
 // Returns an error if closing the connection fails.
 func (c *childConnection) Close() error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	alreadyClosed := c.isClosed.Load()
 	caller := utils.Caller()
 
-	log.Debugf("<%s> attempting to close child connection: %s = %p | closed=%v", caller, c.RemoteAddr().String(), c, alreadyClosed)
-
-	if c.isClosed.Load() {
+	// Flip the closed flag first (atomically) so concurrent closes are mutually
+	// exclusive and any in-flight scan/read sees the closure immediately.
+	if c.isClosed.Swap(true) {
+		log.Debugf("<%s> child connection already closed: %s = %p", caller, c.RemoteAddr().String(), c)
 		return nil
 	}
 
-	x, ok := c.maps.Load(c.RemoteAddr().String())
-	if !ok {
-		log.Panicf("<%s>: cannot find child connection in map: %p | %p", caller, c, x)
+	// Interrupt any read currently blocked on this connection so it returns
+	// promptly and releases its read lock; this keeps Close from blocking behind
+	// a stalled scan and serializes close against scan on the data connection.
+	_ = c.conn.SetDeadline(time.Now())
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if _, ok := c.maps.Load(c.RemoteAddr().String()); !ok {
+		log.Debugf("<%s>: child connection not present in map: %p", caller, c)
 	}
 
 	err := c.conn.Close()
 	if err != nil {
 		err = fmt.Errorf("<%s>: %w", caller, err)
 	}
-
-	c.isClosed.Store(true)
 	c.maps.Delete(c.RemoteAddr().String())
 
-	log.Debugf("closed child connection: %s = %p | closed=%v", c.RemoteAddr().String(), c, c.isClosed.Load())
-
+	log.Debugf("closed child connection: %s = %p", c.RemoteAddr().String(), c)
 	return err
 }
 

--- a/site.go
+++ b/site.go
@@ -3,6 +3,7 @@
 package zftp
 
 import (
+	"context"
 	"fmt"
 	"strings"
 )
@@ -11,10 +12,18 @@ import (
 // translating z/OS "Unrecognized parameter" / "Parameter ignored" replies into
 // errors.
 func (s *FTPSession) Site(subCommand string, a ...string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.siteLocked(subCommand, a...)
+}
+
+// siteLocked issues a single SITE subcommand and interprets z/OS rejection
+// replies. The caller must hold s.mu.
+func (s *FTPSession) siteLocked(subCommand string, a ...string) (string, error) {
 	args := strings.Join(a, " ")
 	subCommand = strings.TrimSpace(strings.ToUpper(subCommand))
 	subCommandWithArgs := fmt.Sprintf("%s %s", subCommand, args)
-	str, err := s.SendCommand(CodeCmdOK, "SITE", subCommandWithArgs)
+	str, err := s.sendLocked(context.Background(), CodeCmdOK, "SITE", subCommandWithArgs)
 	lines := strings.Split(str, "\n")
 	switch {
 	case err != nil:
@@ -32,4 +41,11 @@ func (s *FTPSession) Site(subCommand string, a ...string) (string, error) {
 // SITE) on the current session. See StatusSetter for the available setters.
 func (s *FTPSession) SetStatusOf() *StatusSetter {
 	return &StatusSetter{site: s.Site}
+}
+
+// setStatusOfLocked is like SetStatusOf but its setters assume s.mu is already
+// held. It is used by methods that run a whole sequence under the lock, such as
+// Login, where calling the public (locking) Site would deadlock.
+func (s *FTPSession) setStatusOfLocked() *StatusSetter {
+	return &StatusSetter{site: s.siteLocked}
 }

--- a/transfer.go
+++ b/transfer.go
@@ -3,6 +3,7 @@
 package zftp
 
 import (
+	"context"
 	"fmt"
 	"gopkg.in/ro-ag/zftp.v2/eol"
 	"gopkg.in/ro-ag/zftp.v2/internal/log"
@@ -49,11 +50,25 @@ func (t TransferType) IsBinary() bool {
 
 // SetType sets the transfer type and stores it in the FTPSession.
 func (s *FTPSession) SetType(t TransferType) error {
-	_, err := s.SendCommand(CodeCmdOK, t.strCommand())
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.setTypeLocked(t)
+}
+
+// setTypeLocked issues the TYPE command and records the new transfer type on
+// success. The caller must hold s.mu.
+func (s *FTPSession) setTypeLocked(t TransferType) error {
+	_, err := s.sendLocked(context.Background(), CodeCmdOK, t.strCommand())
 	if err == nil {
-		s.currType = t
+		s.currType.Store(uint32(t))
 	}
 	return err
+}
+
+// currentType returns the session's current transfer type. It is safe to call
+// without holding s.mu.
+func (s *FTPSession) currentType() TransferType {
+	return TransferType(s.currType.Load())
 }
 
 // transfer is a helper function that performs a data transfer.
@@ -114,7 +129,7 @@ func (s *FTPSession) transfer(t transfer.DataTransfer, remote string, offset int
 // supports ASCII and binary/Image transfers
 func (s *FTPSession) StoreIO(remote string, src io.Reader, t TransferType) (int64, string, error) {
 
-	current := s.currType
+	current := s.currentType()
 	if err := s.SetType(t); err != nil {
 		return 0, "", err
 	}
@@ -143,7 +158,7 @@ func (s *FTPSession) StoreIO(remote string, src io.Reader, t TransferType) (int6
 // The transfer type is restored to the previous value after the transfer
 // supports ASCII and binary/Image transfers
 func (s *FTPSession) RetrieveIO(remote string, dest io.Writer, t TransferType) (int64, string, error) {
-	current := s.currType
+	current := s.currentType()
 	if t.IsAscii() {
 		if err := s.SetStatusOf().SBSendEol(eol.System); err != nil {
 			return 0, "", err
@@ -169,7 +184,7 @@ func (s *FTPSession) RetrieveIO(remote string, dest io.Writer, t TransferType) (
 // The transfer type is restored to the previous value after the transfer.
 func (s *FTPSession) StoreIOAt(remote string, src io.Reader, t TransferType, offset int64) (int64, string, error) {
 
-	current := s.currType
+	current := s.currentType()
 	if err := s.SetType(t); err != nil {
 		return 0, "", err
 	}
@@ -197,7 +212,7 @@ func (s *FTPSession) StoreIOAt(remote string, src io.Reader, t TransferType, off
 // RetrieveIOAt performs a retrieve operation starting from the given offset of the remote file.
 // The transfer type is restored to the previous value after the transfer.
 func (s *FTPSession) RetrieveIOAt(remote string, dest io.Writer, t TransferType, offset int64) (int64, string, error) {
-	current := s.currType
+	current := s.currentType()
 	if t.IsAscii() {
 		if err := s.SetStatusOf().SBSendEol(eol.System); err != nil {
 			return 0, "", err


### PR DESCRIPTION
## Summary

Makes `*FTPSession` safe to share across goroutines and fixes a context-timeout bug that silently corrupted the control stream. Delivers **ZH01** (#41, timeout desync) and **ZH08** (#42, concurrency-safety) — they are inseparable.

v2 is not yet tagged, so the breaking API surface (adding `IsClosed()`, serializing every command) is in-scope.

## The bugs

- **Timeout desync (ZH01):** `SendCommandWithContext` wrote the command and read the reply in a spawned goroutine, then `select`ed on `ctx.Done()`. On timeout it returned, but the goroutine kept blocking in `expect.check`. The late reply was later consumed and dropped, leaving the control stream **one reply ahead** — every subsequent command read the *wrong* reply (silent session corruption). The blocking read was never actually cancelled, and `conn`/`reader` were touched concurrently.
- **No concurrency-safety (ZH08):** the command/transfer path took no lock while `Login`/`Close`/`AuthTLS` took `s.mu`, so `Close` could close `conn` under an in-flight command and `conn`/`reader`/`currType`/`system` raced.

## The fix

- Serialize every control round-trip (write + reply) under `s.mu` via an unexported `sendLocked`. Public `SendCommand`/`Site`/`SetType` lock then call it; `Login`/`AuthTLS` (which already hold `s.mu`) call the `*Locked` helpers to avoid re-entrant deadlock (`sync.Mutex` is not reentrant).
- Remove the goroutine: with a context deadline, push it onto the conn (`SetDeadline`) and do the write/read inline. Any I/O-level failure (deadline / EOF / reset) is unrecoverable for an FTP control stream, so the session is **closed** and later commands fail fast instead of reading a stale reply. A complete-but-unexpected reply (`*ReturnError`) keeps the stream in sync and does **not** close.
- Guard `currType` (now `atomic.Uint32`), `system`, and `user`; add `IsClosed()`.
- `Close` interrupts an in-flight read via the underlying socket before taking the mutex, so it can never starve behind a command stalled on a silent peer.
- Harden `childConnection.Close`: idempotent, interrupts an in-flight data scan, and no longer `log.Panicf`s when the conn is already out of the map.

## Adversarial review

Two independent reviewers audited the first cut and found three real defects, all fixed here with regression tests:

1. **(HIGH, regression)** a no-deadline `SendCommand` blocks the read *holding `s.mu`*, so a concurrent `Close` starved forever → `Close` now interrupts the socket before locking.
2. **(HIGH)** `codes.go` collapsed `io.EOF` into a `*ReturnError{rc:0}`, so a peer-closed session was left open (zombie) → EOF-before-complete-reply is now a plain I/O error and closes the session.
3. **(MEDIUM)** `checkLast` (the post-transfer reply reader) didn't close on I/O error → same desync via the transfer/list path; now it does.

## Tests

New `concurrency_test.go` (black-box, in-process `mockzos`, no mainframe): concurrent commands + `Close` race-free, timeout-closes-session, `Close`-unblocks-stalled-command, peer-close-closes-session, post-transfer-EOF-closes-session, concurrent-List+Close-no-panic. `mockzos` gains `Withhold`/`Hangup`/`DropControlAfterData`. Each new test was confirmed to fail before its fix.

## Verification

Local, all green: `CGO_ENABLED=0 go build ./...`, `go vet ./...`, `staticcheck ./...` (exit 0), `go test -race ./...` (incl. concurrency tests ×10, no flakes), `govulncheck ./...` (no vulnerabilities), `gofmt -l` clean.

Closes #41
Closes #42
