### PR TITLE
fix: z/OS data-transfer completion robustness + simplify data connection (ZH15)

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -114,12 +114,24 @@ func (s *FTPSession) CheckLast(expect ReturnCode) (string, error) {
 }
 
 func (s *FTPSession) checkLast(expect ReturnCode) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), s.dialCfg.replyTimeout())
+	defer cancel()
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if s.isClosed.Load() {
 		log.Warningf("<%s> session %s is closed", utils.Caller(), s.conn.RemoteAddr().String())
 		return "", nil
+	}
+
+	// Bound the reply read: z/OS sends the terminal 226/250 asynchronously to the
+	// data-connection close and it can be lost, which would otherwise hang here.
+	if dl, ok := ctx.Deadline(); ok {
+		if err := s.conn.SetDeadline(dl); err != nil {
+			return "", err
+		}
+		defer func() { _ = s.conn.SetDeadline(time.Time{}) }()
 	}
 
 	s.lastMessage.Reset()

--- a/data_conn_test.go
+++ b/data_conn_test.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package zftp_test
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	zftp "gopkg.in/ro-ag/zftp.v2"
+	"gopkg.in/ro-ag/zftp.v2/internal/mockzos"
+)
+
+// TestList_TruncatedData_Errors guards against silent truncation: z/OS aborts a
+// failed transfer with a TCP RST (it uses a clean FIN only on success), so a reset
+// on the data connection means the listing is incomplete and must surface as an
+// error — even when the control reply still says 250.
+func TestList_TruncatedData_Errors(t *testing.T) {
+	s, srv := dialMock(t)
+	srv.DataFor("LIST", "",
+		"Volume Unit    Referred Ext Used Recfm Lrecl BlkSz Dsorg Dsname\r\n"+
+			"FA00FF 3390   2023/06/02  1  360  VB    8004 27998  PS  'ABCD.EF.SEQ'\r\n")
+	srv.TruncateData("LIST") // data connection aborted with RST; control still says 250
+
+	if _, err := s.List("ABCD.EF.*"); err == nil {
+		t.Fatal("List over a reset (truncated) data connection must error, got nil")
+	}
+	// The terminal control reply was left unconsumed, so the control stream is
+	// desynchronized; the session must be closed rather than reused out of phase.
+	if !s.IsClosed() {
+		t.Fatal("session must be closed after a data-stream failure to avoid control-stream desync")
+	}
+}
+
+// errWriter fails every write, to deterministically force a data-stream error
+// mid-retrieve without depending on TCP reset timing.
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) { return 0, errors.New("sink failure") }
+
+// TestRetrieve_SinkError_ClosesSession is the RETR/STOR twin of the LIST case: a
+// data-stream failure (here, the destination writer erroring) leaves the
+// transfer's terminal reply unconsumed, so the session must be closed rather than
+// left desynchronized.
+func TestRetrieve_SinkError_ClosesSession(t *testing.T) {
+	s, srv := dialMock(t)
+	srv.DataFor("RETR", "BIG.BIN", strings.Repeat("z", 64*1024))
+
+	if _, _, err := s.RetrieveIO("BIG.BIN", errWriter{}, zftp.TypeBinary); err == nil {
+		t.Fatal("RetrieveIO with a failing sink must error, got nil")
+	}
+	if !s.IsClosed() {
+		t.Fatal("session must be closed after a failed transfer to avoid control-stream desync")
+	}
+}
+
+// TestList_ConcurrentClose_Aborts verifies that a LIST whose data scan is in
+// flight when the session is closed from another goroutine (e.g. the SIGINT
+// handler) reports an abort error rather than silently returning a partial
+// listing as success.
+func TestList_ConcurrentClose_Aborts(t *testing.T) {
+	s, srv := dialMock(t)
+	srv.DataFor("LIST", "", "FA00FF 3390   2023/06/02  1  360  VB    8004 27998  PS  'ABCD.EF.SEQ'\r\n")
+	srv.HangData("LIST") // server holds the data conn open after the line, so the scan blocks
+
+	listErr := make(chan error, 1)
+	go func() {
+		_, err := s.List("ABCD.EF.*")
+		listErr <- err
+	}()
+	time.Sleep(250 * time.Millisecond) // let the scan drain the line and block on the next read
+
+	closed := make(chan struct{})
+	go func() { _ = s.Close(); close(closed) }()
+	select {
+	case <-closed:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Close hung during a concurrent List")
+	}
+
+	select {
+	case err := <-listErr:
+		if err == nil {
+			t.Error("List aborted by a concurrent Close must error, got nil")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("List did not return after Close")
+	}
+}
+
+// TestList_ReplyTimeout_ClosesSession verifies the post-transfer reply read is
+// bounded: when the data is delivered and closed cleanly but the closing 250
+// never arrives (and the control link stays open), the call must time out, error,
+// and close the session rather than hang forever.
+func TestList_ReplyTimeout_ClosesSession(t *testing.T) {
+	srv := mockzos.New(t)
+	s, err := zftp.Open(srv.Addr(), zftp.WithReplyTimeout(250*time.Millisecond))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	if err := s.Login("ME", "PW"); err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	srv.DataFor("LIST", "", "FA00FF 3390   2023/06/02  1  360  VB    8004 27998  PS  'ABCD.EF.SEQ'\r\n")
+	srv.WithholdReplyAfterData("LIST") // data delivered + closed, but no 250; control stays open
+
+	runWithTimeout(t, 5*time.Second, func() {
+		if _, err := s.List("ABCD.EF.*"); err == nil {
+			t.Error("List must error when the closing reply never arrives, got nil")
+		}
+	})
+	if !s.IsClosed() {
+		t.Error("session must be closed after the post-transfer reply read times out")
+	}
+}
+
+// TestSession_ConcurrentRetrieveAndClose_NoPanic exercises the data-connection
+// Read path (used by io.Copy for RETR) racing a concurrent Close. It must be
+// race-free and not panic — the guard for dropping childConnection's mutex in
+// favor of net.Conn's own concurrency safety plus the close interrupt.
+func TestSession_ConcurrentRetrieveAndClose_NoPanic(t *testing.T) {
+	s, srv := dialMock(t)
+	srv.DataFor("RETR", "BIG.BIN", strings.Repeat("0123456789abcdef", 16*1024)) // 256 KiB
+
+	runWithTimeout(t, 10*time.Second, func() {
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var buf bytes.Buffer
+			_, _, _ = s.RetrieveIO("BIG.BIN", &buf, zftp.TypeBinary)
+		}()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = s.Close()
+		}()
+		wg.Wait()
+	})
+}

--- a/internal/mockzos/script.go
+++ b/internal/mockzos/script.go
@@ -102,6 +102,57 @@ func (s *Server) isDropAfterData(verb string) bool {
 	return s.dropAfterData[verb]
 }
 
+// TruncateData makes a download (LIST/NLST/RETR) abort its data connection with a
+// TCP RST (SO_LINGER 0) instead of a clean FIN after sending the payload, while
+// the control connection still reports 250. It models a failed/aborted z/OS
+// transfer, so the client must fail the operation on the data-stream error even
+// though the control reply looks successful. The key is a verb.
+func (s *Server) TruncateData(verb string) {
+	key := strings.ToUpper(strings.TrimSpace(verb))
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.truncate[key] = true
+}
+
+func (s *Server) isTruncateData(verb string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.truncate[verb]
+}
+
+// HangData makes a download hold its data connection open after sending the
+// payload (blocking until the client closes it), so the client's scan stalls and
+// a concurrent Close can be exercised. The key is a verb.
+func (s *Server) HangData(verb string) {
+	key := strings.ToUpper(strings.TrimSpace(verb))
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.hangData[key] = true
+}
+
+func (s *Server) isHangData(verb string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.hangData[verb]
+}
+
+// WithholdReplyAfterData makes a download deliver its data and cleanly close the
+// data connection, but never send the closing 250 reply, leaving the control
+// connection open so the client's post-transfer reply read blocks (and must time
+// out). The key is a verb.
+func (s *Server) WithholdReplyAfterData(verb string) {
+	key := strings.ToUpper(strings.TrimSpace(verb))
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.withholdReply[key] = true
+}
+
+func (s *Server) isWithholdReplyAfterData(verb string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.withholdReply[verb]
+}
+
 // Commands returns a copy of every command line the server has received, in
 // order, so tests can assert on the exact control sequence (e.g. TYPE/SITE/REST).
 func (s *Server) Commands() []string {

--- a/internal/mockzos/server.go
+++ b/internal/mockzos/server.go
@@ -42,6 +42,9 @@ type Server struct {
 	withheld      map[string]bool     // full line or verb (upper) -> swallow without replying
 	hangup        map[string]bool     // full line or verb (upper) -> drop the control conn without replying
 	dropAfterData map[string]bool     // download verb (upper) -> drop control after data, before the closing reply
+	truncate      map[string]bool     // download verb (upper) -> RST the data conn instead of a clean close
+	hangData      map[string]bool     // download verb (upper) -> hold the data conn open after sending payload
+	withholdReply map[string]bool     // download verb (upper) -> deliver data + clean close, but send no closing reply
 	received      []string            // every command line received, in order
 }
 
@@ -63,6 +66,9 @@ func New(tb testing.TB) *Server {
 		withheld:      map[string]bool{},
 		hangup:        map[string]bool{},
 		dropAfterData: map[string]bool{},
+		truncate:      map[string]bool{},
+		hangData:      map[string]bool{},
+		withholdReply: map[string]bool{},
 	}
 	s.wg.Add(1)
 	go s.serve()
@@ -220,11 +226,39 @@ func (s *Server) handleDownload(sess *session, line, verb, arg string) {
 	}
 	writeLines(sess.conn, []string{"125 data connection already open; transfer starting"})
 	_, _ = dc.Write([]byte(payload))
+
+	// HangData: hold the data connection open after sending the payload so the
+	// client's scan blocks; block here until the client tears the connection down
+	// (e.g. via a concurrent Close).
+	if s.isHangData(verb) {
+		var sink strings.Builder
+		_, _ = copyAll(&sink, dc)
+		return
+	}
+
+	// TruncateData: abort the data connection with a RST (SO_LINGER 0) instead of a
+	// clean FIN, modeling a failed/aborted z/OS transfer. The control reply still
+	// says 250, so only the data-stream error should fail the operation.
+	if s.isTruncateData(verb) {
+		if tcp, ok := dc.(*net.TCPConn); ok {
+			_ = tcp.SetLinger(0)
+		}
+		_ = dc.Close()
+		writeLines(sess.conn, []string{"250 transfer completed successfully"})
+		return
+	}
+
 	_ = dc.Close()
-	// Optionally drop the control connection after the data has been delivered but
-	// before the closing reply, so the client's post-transfer reply read hits EOF.
+	// DropControlAfterData: drop the control connection after the data has been
+	// delivered but before the closing reply, so the reply read hits EOF.
 	if s.isDropAfterData(verb) {
 		_ = sess.conn.Close()
+		return
+	}
+	// WithholdReplyAfterData: deliver and cleanly close the data, but never send the
+	// closing reply, leaving the control connection open so the reply read blocks
+	// and must time out.
+	if s.isWithholdReplyAfterData(verb) {
 		return
 	}
 	writeLines(sess.conn, []string{"250 transfer completed successfully"})

--- a/lists.go
+++ b/lists.go
@@ -3,6 +3,7 @@
 package zftp
 
 import (
+	"errors"
 	"fmt"
 	"gopkg.in/ro-ag/zftp.v2/hfs"
 	"gopkg.in/ro-ag/zftp.v2/internal/log"
@@ -57,19 +58,10 @@ func (s *FTPSession) anyList(cmd, expression string) ([]string, string, error) {
 		return nil, resp, fmt.Errorf("error while sending list command: %w", err)
 	}
 
-	lines, err := make([]string, 0), error(nil)
-
-	for child.Scanner().Scan() {
-		if child.IsClosed() {
-			break
-		}
-		line := child.Scanner().Text()
-		if err := child.Scanner().Err(); err != nil {
-			if err.Error() == "EOF" {
-				break
-			}
-			return nil, resp, fmt.Errorf("error while scanning child connection: %w", err)
-		}
+	lines := make([]string, 0)
+	sc := child.Scanner()
+	for sc.Scan() {
+		line := sc.Text()
 		if trimLine {
 			line = strings.TrimSpace(line)
 		}
@@ -77,14 +69,25 @@ func (s *FTPSession) anyList(cmd, expression string) ([]string, string, error) {
 		log.Passivef("%s", line)
 	}
 
-	err = child.Close()
-	if err != nil {
-		return nil, resp, err
+	// Classify why the scan stopped before trusting the result. A concurrent close
+	// (session Close / SIGINT handler tearing down the data connection) is an
+	// abort; a read error — a z/OS RST on a failed transfer, or a line exceeding
+	// the scanner's bound — means the listing is incomplete; a clean EOF (no error,
+	// not closed by us) is success.
+	if child.IsClosed() {
+		return nil, resp, errors.New("list aborted: data connection closed")
+	}
+	if err := sc.Err(); err != nil {
+		// A data-stream failure (a z/OS RST on a failed transfer, or a line over
+		// the scanner's bound) leaves the listing's terminal control reply
+		// unconsumed, desynchronizing the control stream. Close the session so it
+		// is not reused one reply out of phase.
+		_ = s.Close()
+		return nil, resp, fmt.Errorf("error reading list data connection: %w", err)
 	}
 
-	_, err = s.checkLast(CodeFileActionOK)
-	if err != nil {
-		return nil, resp, fmt.Errorf("error while checking last response: %w", err)
+	if _, err := s.confirmData(child); err != nil {
+		return nil, resp, fmt.Errorf("error confirming list transfer: %w", err)
 	}
 	return lines, resp, nil
 }

--- a/options.go
+++ b/options.go
@@ -11,8 +11,24 @@ type Option func(*dialOptions)
 type dialOptions struct {
 	DialTimeout     time.Duration
 	KeepAlivePeriod time.Duration
+	ReplyTimeout    time.Duration
 	dialer          Dialer
 	signalHandler   bool
+}
+
+// defaultReplyTimeout bounds the wait for a post-transfer control reply. It is
+// generous (a well-behaved z/OS server answers in well under a second) but finite,
+// so a lost reply cannot hang the caller forever. It mirrors the z/OS DATATIMEOUT
+// default of 120s.
+const defaultReplyTimeout = 120 * time.Second
+
+// replyTimeout returns the configured post-transfer reply timeout, falling back to
+// defaultReplyTimeout when unset.
+func (o dialOptions) replyTimeout() time.Duration {
+	if o.ReplyTimeout <= 0 {
+		return defaultReplyTimeout
+	}
+	return o.ReplyTimeout
 }
 
 // apply runs the option functions on a dialOptions struct.
@@ -49,4 +65,14 @@ func WithTimeout(d time.Duration) Option {
 // A zero duration disables keep-alives.
 func WithKeepAlive(d time.Duration) Option {
 	return func(o *dialOptions) { o.KeepAlivePeriod = d }
+}
+
+// WithReplyTimeout bounds how long the client waits for the terminal reply (the
+// 226/250 that follows a data transfer). z/OS sends that reply asynchronously to
+// the data-connection close, and it can be lost — for example a NAT dropping an
+// idle control link during a long transfer — so bounding the read keeps a lost
+// reply from hanging the caller. Defaults to 120s; a non-positive duration
+// restores the default.
+func WithReplyTimeout(d time.Duration) Option {
+	return func(o *dialOptions) { o.ReplyTimeout = d }
 }

--- a/passive.go
+++ b/passive.go
@@ -69,36 +69,26 @@ func findPort(line string) (int, error) {
 	return port, nil
 }
 
-// connectDataConn is a wrapper over net.Dial that sets a timeout on the connection.
-// its has mutex control to allow graceful closing of the connection.
+// childConnection is a passive-mode data connection. It embeds net.Conn — so it
+// satisfies the interface the transfer helpers expect, with Read/Write/deadline/
+// address methods coming straight from the socket — and overrides Close to make
+// teardown idempotent, interrupt an in-flight read, and deregister from the
+// session's data-connection map.
+//
+// No mutex is needed: net.Conn is safe for concurrent Read/Write/Close, the closed
+// state is an atomic flag, and Close interrupts a blocked read by pushing a past
+// deadline onto the socket before closing it.
 type childConnection struct {
-	conn     net.Conn
+	net.Conn
 	parent   net.Addr
 	maps     *sync.Map
 	scan     *scanner
-	mu       sync.RWMutex
 	isClosed atomic.Bool
 }
 
-// Read is a wrapper over net.Conn.Read that sets a timeout on the connection.
-func (c *childConnection) Read(b []byte) (n int, err error) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	return c.conn.Read(b)
-}
-
-// Write is a wrapper over net.Conn.Write that sets a timeout on the connection.
-func (c *childConnection) Write(b []byte) (n int, err error) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	return c.conn.Write(b)
-}
-
-// Close closes the connection.
-// It acquires an exclusive lock to ensure exclusive access to the connection.
-// It checks the isClosed flag to avoid closing the connection multiple times.
-// It updates the isClosed flag and deletes the connection from the maps.
-// Returns an error if closing the connection fails.
+// Close tears down the data connection. It is idempotent and safe to call
+// concurrently with an in-flight Read/Write/scan, which it interrupts so the
+// reader observes the closure promptly.
 func (c *childConnection) Close() error {
 	caller := utils.Caller()
 
@@ -110,18 +100,14 @@ func (c *childConnection) Close() error {
 	}
 
 	// Interrupt any read currently blocked on this connection so it returns
-	// promptly and releases its read lock; this keeps Close from blocking behind
-	// a stalled scan and serializes close against scan on the data connection.
-	_ = c.conn.SetDeadline(time.Now())
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	// promptly; net.Conn permits SetDeadline and Close concurrently with Read/Write.
+	_ = c.Conn.SetDeadline(time.Now())
 
 	if _, ok := c.maps.Load(c.RemoteAddr().String()); !ok {
 		log.Debugf("<%s>: child connection not present in map: %p", caller, c)
 	}
 
-	err := c.conn.Close()
+	err := c.Conn.Close()
 	if err != nil {
 		err = fmt.Errorf("<%s>: %w", caller, err)
 	}
@@ -131,45 +117,17 @@ func (c *childConnection) Close() error {
 	return err
 }
 
-// IsClosed returns true if the connection is closed, false otherwise.
-// its uses atomic operations to read the isClosed flag.
+// IsClosed reports whether the data connection has been closed.
 func (c *childConnection) IsClosed() bool {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
 	return c.isClosed.Load()
 }
 
-// LocalAddr wraps net.Conn.LocalAddr
-func (c *childConnection) LocalAddr() net.Addr {
-	return c.conn.LocalAddr()
-}
-
-// RemoteAddr wraps net.Conn.RemoteAddr
-func (c *childConnection) RemoteAddr() net.Addr {
-	return c.conn.RemoteAddr()
-}
-
-// ParentAddr returns the address of the parent connection.
+// ParentAddr returns the address of the parent (control) connection.
 func (c *childConnection) ParentAddr() net.Addr {
 	return c.parent
 }
 
-// SetDeadline wraps net.Conn.SetDeadline
-func (c *childConnection) SetDeadline(t time.Time) error {
-	return c.conn.SetDeadline(t)
-}
-
-// SetReadDeadline wraps net.Conn.SetReadDeadline
-func (c *childConnection) SetReadDeadline(t time.Time) error {
-	return c.conn.SetReadDeadline(t)
-}
-
-// SetWriteDeadline wraps net.Conn.SetWriteDeadline
-func (c *childConnection) SetWriteDeadline(t time.Time) error {
-	return c.conn.SetWriteDeadline(t)
-}
-
-// Scanner returns a new scanner for the connection
+// Scanner returns the line scanner bound to this connection.
 func (c *childConnection) Scanner() *scanner {
 	return c.scan
 }
@@ -212,12 +170,12 @@ func (s *FTPSession) newChildConnection(port int) (*childConnection, error) {
 		log.Debugf("upgraded connection to TLS")
 	}
 
-	child := childConnection{conn: conn, parent: conn.RemoteAddr(), maps: &s.dataConns}
+	child := &childConnection{Conn: conn, parent: conn.RemoteAddr(), maps: &s.dataConns}
 	child.scan = newScanner(conn, child.IsClosed)
-	s.dataConns.Store(child.RemoteAddr().String(), &child)
+	s.dataConns.Store(child.RemoteAddr().String(), child)
 
 	log.Debugf("created child connection: %s", child.RemoteAddr().String())
-	return &child, nil
+	return child, nil
 }
 
 // newScanner returns a new scanner for the connection

--- a/transfer.go
+++ b/transfer.go
@@ -106,20 +106,31 @@ func (s *FTPSession) transfer(t transfer.DataTransfer, remote string, offset int
 
 	sz, err := t.Transfer(child)
 	if err != nil {
+		// A data-stream failure leaves the transfer's terminal control reply
+		// unconsumed, desynchronizing the control stream; close the session so it
+		// is not reused one reply out of phase.
+		_ = s.Close()
 		return sz, msg1, err
 	}
 
-	err = child.Close()
+	msg2, err := s.confirmData(child)
 	if err != nil {
-		return sz, msg1, err
-	}
-
-	msg2, err := s.checkLast(CodeFileActionOK)
-	if err != nil {
-		return sz, "", fmt.Errorf("error while checking last response: %w", err)
+		return sz, msg1, fmt.Errorf("error while checking last response: %w", err)
 	}
 
 	return sz, fmt.Sprintf("%s\n%s", msg1, msg2), nil
+}
+
+// confirmData finalizes a data transfer. The caller must have already drained the
+// data connection to EOF — closing it with unread bytes would make the local TCP
+// stack emit an RST. It closes the data connection and reads the terminal reply on
+// the control connection; that read is timeout-bounded by checkLast because z/OS
+// sends the reply asynchronously to the data close and it can be lost.
+func (s *FTPSession) confirmData(child *childConnection) (string, error) {
+	if err := child.Close(); err != nil {
+		return "", err
+	}
+	return s.checkLast(CodeFileActionOK)
 }
 
 // StoreIO stores the contents of the reader to the remote file in the specified


### PR DESCRIPTION
## Summary

Makes z/OS directory-listing and transfer **completion** correct against real data-connection behavior, and simplifies the data-connection type. Delivers **ZH15** (#44, list/store robustness).

> Stacked on #43 (`harden/cmd-concurrency-timeout`) — base this on that branch; it retargets to `main` once #43 merges. Diff shown is the delta over #43.

## The bugs (grounded in z/OS Comm Server docs)

- **Silent truncation.** `anyList` checked the scanner error *inside* the loop, where `bufio` guarantees it is `nil`, and never after. z/OS aborts a **failed** transfer with a TCP **RST** (it sets `SO_LINGER` off for a clean FIN only on *success* — IBM APAR PQ54076), and a record could exceed `bufio`'s 64 KB token cap. Either stopped the scan and the error was **dropped** → a partial listing returned as success.
- **Unbounded reply read.** The post-transfer 226/250 arrives asynchronously to the data-connection close (RFC 959 §5.2) and can be lost (a NAT dropping the control link during a long transfer). `checkLast` had no timeout, so a lost reply **hung the caller forever**.
- **Redundant mutex.** `childConnection`'s `RWMutex` guarded no mutable state — `net.Conn` is already safe for concurrent Read/Write/Close, and `Close` interrupts an in-flight read via `SetDeadline`.

## The fix

- **`anyList` error classification** (after the loop): concurrent session close → **abort**; a read error (RST / oversized line) → **failure**; clean EOF → success. On a data-stream failure the terminal control reply is unconsumed, so the **session is closed** to avoid reuse on a desynchronized control stream. The RETR/STOR path (`transfer`) now does the same on a data error.
- **Bounded reply read** via a shared `confirmData` helper + **`WithReplyTimeout`** (default 120s). A lost reply now errors and closes the session instead of hanging.
- **`childConnection` embeds `net.Conn`** and drops the `RWMutex`; `IsClosed()` is a lock-free atomic read.

## Adversarial review caught a real one

The first cut surfaced the data error correctly but **left the session open and desynced** (the next command would read the wrong reply with `err=nil`) — the exact corruption class this targets. Fixed: data-stream failures now close the session; the pre-existing RETR/STOR twin is closed too. Re-verified.

## Tests

New `data_conn_test.go` (in-process `mockzos`, no mainframe): truncation-errors-and-closes, concurrent-close-aborts, reply-timeout-closes-session, the RETR sink-error twin, and a concurrent retrieve+close race. `mockzos` gains `TruncateData` (RST), `HangData` (stall the scan), `WithholdReplyAfterData` (drop the closing reply). Each new test was confirmed to fail before its fix.

## Verification

All green: `go build ./...`, `go vet ./...`, `staticcheck ./...` (exit 0), `go test -race ./...` (incl. new tests ×5, no flakes), `govulncheck ./...` (no vulnerabilities), `gofmt -l` clean.

Closes #44
