### PR TITLE
fix: anchor multiline FTP reply terminator to the opening reply code (ZH02)

### DIFF
--- a/codes.go
+++ b/codes.go
@@ -75,12 +75,23 @@ func (e *ReturnError) Error() string {
 	return fmt.Sprintf("FTP response code: got %d, want %d, message: %s", e.rc, e.wantRc, e.message)
 }
 
-// check checks the response code and returns the message
+// check reads a (possibly multiline) FTP reply and returns its message.
+//
+// Per RFC 959 §4.2 a reply is one or more lines; the first parseable line sets
+// the reply's code, and the reply terminates only on a line that repeats that
+// exact OPENING code followed by a space. Intermediate continuation lines may
+// contain anything — including text that itself begins with "NNN " for some
+// other code (e.g. a z/OS message quoting "550 dataset..." inside a 211 block),
+// which must NOT be mistaken for the terminator. Anchoring the terminator to the
+// opening code keeps such replies whole and the control stream in sync for the
+// next command. Every line is appended (including lines shorter than 4 bytes) so
+// no reply text is lost.
 func (code ReturnCode) check(reader *bufio.Reader) (msg string, err error) {
 
 	var (
-		response     strings.Builder
-		receivedCode = 0
+		response    strings.Builder
+		openingCode = 0
+		haveOpening = false
 	)
 
 	for {
@@ -93,7 +104,7 @@ func (code ReturnCode) check(reader *bufio.Reader) (msg string, err error) {
 				// callers close the desynchronized session instead of mistaking it
 				// for a ReturnError. If a complete reply was already read, fall
 				// through and let the code-mismatch logic below report it.
-				if receivedCode == 0 {
+				if !haveOpening {
 					return response.String(), io.ErrUnexpectedEOF
 				}
 				break
@@ -103,44 +114,47 @@ func (code ReturnCode) check(reader *bufio.Reader) (msg string, err error) {
 
 		log.Serverf("%s", line)
 
-		// We only check the response code if we've read a complete line
+		// Parse the leading 3-digit code when the line is long enough to carry
+		// one. The first line that parses fixes the reply's opening code.
+		lineCode := 0
+		haveLineCode := false
 		if len(line) >= 4 {
-
-			tempReceivedCode, atoiErr := strconv.Atoi(string(line[:3]))
-			if atoiErr != nil {
+			if c, atoiErr := strconv.Atoi(string(line[:3])); atoiErr != nil {
 				log.Errorf("converting response code to integer: %s", atoiErr)
 			} else {
-				receivedCode = tempReceivedCode
-			}
-
-			if receivedCode == int(code) {
-				response.Write(line[4:])
-			} else {
-				response.Write(line) // Keep thew whole response to isolate the error
-			}
-
-			if isPrefix {
-				// If the line is too long to fit in the buffer, we read the rest of the line
-				response.WriteString("\n")
-				continue
-			}
-
-			if line[3] == '-' {
-				response.WriteString("\n")
-				continue
-			}
-
-			if line[3] == ' ' {
-				// If we've found the expected response code and the line ends with a space,
-				// we can return that the code is OK, along with the response
-				break
+				lineCode = c
+				haveLineCode = true
+				if !haveOpening {
+					openingCode = lineCode
+					haveOpening = true
+				}
 			}
 		}
+
+		// Append every line so no reply text is lost. Strip the redundant "NNN "
+		// prefix only on lines that carry the expected code; keep continuation or
+		// error lines whole so their codes stay visible in the message.
+		if haveLineCode && lineCode == int(code) {
+			response.Write(line[4:])
+		} else {
+			response.Write(line)
+		}
+
+		// The reply terminates only on a complete line that repeats the OPENING
+		// code followed by a space. A line whose 4th byte is a space but whose
+		// code differs is a continuation, not the end; line[3] == '-' is always a
+		// continuation; isPrefix means the line was truncated by the read buffer
+		// and so cannot be a terminator.
+		if !isPrefix && haveLineCode && line[3] == ' ' && lineCode == openingCode {
+			break
+		}
+
+		response.WriteString("\n")
 	}
 
-	if receivedCode != int(code) {
+	if !haveOpening || openingCode != int(code) {
 		return response.String(), &ReturnError{
-			rc:      receivedCode,
+			rc:      openingCode,
 			message: response.String(),
 			wantRc:  int(code),
 		}

--- a/codes_test.go
+++ b/codes_test.go
@@ -57,3 +57,65 @@ func TestSendCommand_Success(t *testing.T) {
 		t.Errorf("msg = %q", msg)
 	}
 }
+
+// TestSendCommand_DeceptiveMidlineNotTerminator guards the RFC 959 §4.2
+// terminator rule: a multiline reply ends only on a line that repeats the
+// OPENING reply code followed by a space. A continuation line that merely looks
+// like a terminator — three digits and a space, but a DIFFERENT code (here a
+// z/OS message quoting "550 ...") — must be treated as a continuation, not the
+// end. Otherwise the reply is truncated and the real terminator line desyncs the
+// control stream for the next command.
+func TestSendCommand_DeceptiveMidlineNotTerminator(t *testing.T) {
+	s, srv := dialMock(t)
+	srv.Script("STAT", "211-begin", "550 not the end", "211 actual end")
+	srv.Script("NOOP", "200 its own reply")
+
+	msg, err := s.SendCommand(zftp.CodeSysStatus, "STAT") // expects 211
+	if err != nil {
+		t.Fatalf("STAT: unexpected error (reply mis-terminated?): %v", err)
+	}
+	for _, want := range []string{"begin", "550 not the end", "actual end"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("reply truncated: missing %q in:\n%s", want, msg)
+		}
+	}
+
+	// Core desync guard: the leftover real terminator must not bleed into the
+	// next command — NOOP must read its OWN reply.
+	msg2, err := s.SendCommand(zftp.CodeCmdOK, "NOOP") // expects 200
+	if err != nil {
+		t.Fatalf("NOOP after multiline: control stream desynced: %v", err)
+	}
+	if !strings.Contains(msg2, "its own reply") {
+		t.Errorf("NOOP read a stale reply (desync): %q", msg2)
+	}
+}
+
+// TestSendCommand_ShortContinuationLineRetained verifies that a continuation
+// line shorter than 4 bytes (here a blank line) inside a multiline block is
+// retained in the response — not silently dropped — and that parsing still
+// terminates on the real terminator and leaves the stream in sync.
+func TestSendCommand_ShortContinuationLineRetained(t *testing.T) {
+	s, srv := dialMock(t)
+	srv.Script("STAT", "211-header", "", "211 footer")
+	srv.Script("NOOP", "200 still in sync")
+
+	msg, err := s.SendCommand(zftp.CodeSysStatus, "STAT") // expects 211
+	if err != nil {
+		t.Fatalf("STAT: unexpected error: %v", err)
+	}
+	for _, want := range []string{"header", "footer"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("missing %q in:\n%s", want, msg)
+		}
+	}
+	// The blank continuation line is retained as an empty line between the two.
+	if !strings.Contains(msg, "header\n\nfooter") {
+		t.Errorf("blank continuation line dropped; got:\n%q", msg)
+	}
+
+	// The reply terminated correctly, so the next command stays in sync.
+	if _, err := s.SendCommand(zftp.CodeCmdOK, "NOOP"); err != nil {
+		t.Fatalf("NOOP after short continuation line: desync: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #49

## Problem (RFC 959 §4.2)

`ReturnCode.check` (codes.go) ended a multiline reply at the **first** line whose
4th byte was a space, regardless of the 3-digit code on that line. RFC 959 §4.2
says a multiline reply terminates only on a line that repeats the **opening**
reply code followed by a space; intermediate continuation lines must not be
mistaken for it.

So a continuation line beginning with `NNN ` for a *different* code — e.g. a z/OS
message quoting `550 dataset...` or `200 blocks` inside a `211-`/`125-` block —
was mis-detected as the terminator. The reply was **truncated** and the remaining
real terminator line(s) **desynced the control stream for the next command**.

Secondary: lines shorter than 4 bytes were silently dropped from the response.

## Fix

- Capture the opening reply code from the first parseable (`len >= 4`) line.
- Treat a line as the terminator **only** when its parsed code equals the opening
  code **and** its 4th byte is a space. A `line[3]==' '` line with a different
  code is a continuation; `line[3]=='-'` is always a continuation.
- Append every line (including lines `< 4` bytes) so no reply text is lost.
- Preserve the #41 behavior: an EOF/peer-close before a complete reply returns
  `io.ErrUnexpectedEOF` so the caller closes the desynchronized session. A
  complete-but-unexpected code still returns `*ReturnError` (now carrying the
  reply's actual opening code) with the stream left in sync.

## Tests (TDD, RED→GREEN, under `-race`)

Driven through the in-process `internal/mockzos` server:

- **`TestSendCommand_DeceptiveMidlineNotTerminator`** — a `211-` reply whose middle
  line is `550 not the end` returns the *full* three-line message, and a
  subsequent `NOOP` reads **its own** reply (core desync guard).
- **`TestSendCommand_ShortContinuationLineRetained`** — a blank (`< 4` byte)
  continuation line inside a multiline block is retained and parsing still
  terminates correctly, stream stays in sync.
- Existing guards still green: normal multiline (terminator repeats opening code),
  wrong-code → `*ReturnError`, EOF-before-reply → session closed.

## Gate (local, all green)

- `CGO_ENABLED=0 go build ./...`
- `CGO_ENABLED=0 go vet ./...`
- `staticcheck ./...`
- `go test -race ./...`
- `govulncheck ./...` — no vulnerabilities