### PR TITLE
fix: reject ASCII transfers resumed by byte offset (REST)

### DIFF
--- a/get.go
+++ b/get.go
@@ -45,7 +45,16 @@ func (s *FTPSession) Get(remote string, localFile string, mode TransferType) err
 
 // GetAt retrieves a file from the FTP server starting at a given offset.
 // The data is written to the local file beginning at the same offset.
+//
+// Resume requires image/binary mode: a positive offset combined with TypeAscii
+// returns ErrAsciiResumeUnsupported before the local file is opened, created, or
+// truncated, because in ASCII mode the server's EOL/codepage translation makes a
+// byte offset corrupt the data.
 func (s *FTPSession) GetAt(remote string, localFile string, mode TransferType, offset int64) error {
+	if err := guardResume(mode, offset); err != nil {
+		return err
+	}
+
 	log.Debug("opening local file: ", localFile)
 
 	file, err := os.OpenFile(localFile, os.O_CREATE|os.O_WRONLY, 0644)

--- a/get_put_mock_test.go
+++ b/get_put_mock_test.go
@@ -4,6 +4,7 @@ package zftp_test
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -43,5 +44,49 @@ func TestPutGet_BinaryRoundTrip(t *testing.T) {
 	}
 	if !bytes.Equal(got, content) {
 		t.Errorf("downloaded = % x, want % x", got, content)
+	}
+}
+
+// TestGetAt_AsciiOffsetRejected_LocalUntouched verifies GetAt rejects an ASCII
+// byte-offset resume before touching the local file: the destination (which does
+// not exist yet) must not be created, and no control command may be sent.
+func TestGetAt_AsciiOffsetRejected_LocalUntouched(t *testing.T) {
+	s, srv := dialMock(t)
+	srv.DataFor("RETR", "BIG.SEQ", "tail-bytes")
+	dir := t.TempDir()
+	local := filepath.Join(dir, "out.txt") // intentionally absent
+
+	before := len(srv.Commands())
+	err := s.GetAt("BIG.SEQ", local, zftp.TypeAscii, 100)
+	if !errors.Is(err, zftp.ErrAsciiResumeUnsupported) {
+		t.Fatalf("err = %v, want ErrAsciiResumeUnsupported", err)
+	}
+	if _, statErr := os.Stat(local); !os.IsNotExist(statErr) {
+		t.Errorf("local file was created/touched on rejected ASCII resume (stat err = %v)", statErr)
+	}
+	if after := srv.Commands(); len(after) != before {
+		t.Errorf("rejected ASCII resume sent control command(s): %v", after[before:])
+	}
+}
+
+// TestPutAt_AsciiOffsetRejected_BeforeOpen verifies PutAt rejects an ASCII
+// byte-offset resume before opening/seeking the source: pointing it at a
+// non-existent source must still return ErrAsciiResumeUnsupported (not an
+// open/seek error), proving the guard precedes local-file and network I/O.
+func TestPutAt_AsciiOffsetRejected_BeforeOpen(t *testing.T) {
+	s, srv := dialMock(t)
+	dir := t.TempDir()
+	src := filepath.Join(dir, "does-not-exist.txt") // intentionally absent
+
+	before := len(srv.Commands())
+	err := s.PutAt(src, "OUT.TXT", zftp.TypeAscii, 100)
+	if !errors.Is(err, zftp.ErrAsciiResumeUnsupported) {
+		t.Fatalf("err = %v, want ErrAsciiResumeUnsupported (guard must precede opening the source)", err)
+	}
+	if after := srv.Commands(); len(after) != before {
+		t.Errorf("rejected ASCII resume sent control command(s): %v", after[before:])
+	}
+	if _, ok := srv.Stored("OUT.TXT"); ok {
+		t.Errorf("server stored data on a rejected ASCII resume")
 	}
 }

--- a/put.go
+++ b/put.go
@@ -68,7 +68,16 @@ func (s *FTPSession) Put(srcLocal string, destRemote string, mode TransferType, 
 
 // PutAt resumes uploading a file starting from the given offset.
 // If dataset attributes are provided, they will be applied before the transfer.
+//
+// Resume requires image/binary mode: a positive offset combined with TypeAscii
+// returns ErrAsciiResumeUnsupported before the source file is opened or seeked and
+// before any SITE/REST is sent, because in ASCII mode the server's EOL/codepage
+// translation makes a byte offset corrupt the data.
 func (s *FTPSession) PutAt(srcLocal string, destRemote string, mode TransferType, offset int64, a ...DataSpec) error {
+
+	if err := guardResume(mode, offset); err != nil {
+		return err
+	}
 
 	if len(a) > 0 {
 		log.Debug("dataset attributes passed to PutAt()")

--- a/transfer.go
+++ b/transfer.go
@@ -4,12 +4,33 @@ package zftp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"gopkg.in/ro-ag/zftp.v2/eol"
 	"gopkg.in/ro-ag/zftp.v2/internal/log"
 	"gopkg.in/ro-ag/zftp.v2/internal/transfer"
 	"io"
 )
+
+// ErrAsciiResumeUnsupported is returned by the *At transfer methods when a
+// byte-offset resume (REST) is requested for an ASCII transfer. A REST argument
+// is a byte position, which only has a stable correspondence to a remote position
+// in image/binary mode. In TYPE A the server performs end-of-line and codepage
+// translation, so resuming by byte offset slices mid-record and silently corrupts
+// the data. Resume requires image/binary mode (TypeImage/TypeBinary).
+var ErrAsciiResumeUnsupported = errors.New("zftp: byte-offset resume (REST) requires image/binary mode; ASCII transfers cannot be resumed by byte offset")
+
+// guardResume rejects a byte-offset resume that cannot be honored. It returns
+// ErrAsciiResumeUnsupported when a positive offset is paired with an ASCII
+// transfer type and nil otherwise. The check lives here so every *At entry point
+// (RetrieveIOAt, StoreIOAt, GetAt, PutAt) enforces the same rule before any
+// local-file or network I/O. Image/binary resume (offset > 0) is unaffected.
+func guardResume(t TransferType, offset int64) error {
+	if offset > 0 && t.IsAscii() {
+		return ErrAsciiResumeUnsupported
+	}
+	return nil
+}
 
 // TransferType is the FTP representation type for a transfer. It is a concrete
 // enum (not an interface): callers pass one of the exported values rather than
@@ -193,7 +214,15 @@ func (s *FTPSession) RetrieveIO(remote string, dest io.Writer, t TransferType) (
 
 // StoreIOAt performs a store operation starting at the given offset on the remote file.
 // The transfer type is restored to the previous value after the transfer.
+//
+// Resume requires image/binary mode: a positive offset combined with TypeAscii
+// returns ErrAsciiResumeUnsupported before any I/O, because in ASCII mode the
+// server's EOL/codepage translation makes a byte offset corrupt the data.
 func (s *FTPSession) StoreIOAt(remote string, src io.Reader, t TransferType, offset int64) (int64, string, error) {
+
+	if err := guardResume(t, offset); err != nil {
+		return 0, "", err
+	}
 
 	current := s.currentType()
 	if err := s.SetType(t); err != nil {
@@ -222,7 +251,14 @@ func (s *FTPSession) StoreIOAt(remote string, src io.Reader, t TransferType, off
 
 // RetrieveIOAt performs a retrieve operation starting from the given offset of the remote file.
 // The transfer type is restored to the previous value after the transfer.
+//
+// Resume requires image/binary mode: a positive offset combined with TypeAscii
+// returns ErrAsciiResumeUnsupported before any I/O, because in ASCII mode the
+// server's EOL/codepage translation makes a byte offset corrupt the data.
 func (s *FTPSession) RetrieveIOAt(remote string, dest io.Writer, t TransferType, offset int64) (int64, string, error) {
+	if err := guardResume(t, offset); err != nil {
+		return 0, "", err
+	}
 	current := s.currentType()
 	if t.IsAscii() {
 		if err := s.SetStatusOf().SBSendEol(eol.System); err != nil {

--- a/transfer_mock_test.go
+++ b/transfer_mock_test.go
@@ -4,6 +4,7 @@ package zftp_test
 
 import (
 	"bytes"
+	"errors"
 	"strings"
 	"testing"
 
@@ -95,5 +96,69 @@ func TestRetrieveIOAt_Offset(t *testing.T) {
 	}
 	if buf.String() != "tail-bytes" {
 		t.Errorf("data = %q, want tail-bytes", buf.String())
+	}
+}
+
+// TestRetrieveIOAt_AsciiOffsetRejected verifies that requesting a byte-offset
+// resume in ASCII mode is rejected with ErrAsciiResumeUnsupported before any I/O:
+// in TYPE A the server translates EOL/codepage, so a byte offset would slice
+// mid-record and corrupt the data. No control command (REST/RETR/TYPE) may be
+// sent and nothing may be written to the destination.
+func TestRetrieveIOAt_AsciiOffsetRejected(t *testing.T) {
+	s, srv := dialMock(t)
+	srv.DataFor("RETR", "BIG.SEQ", "should-not-be-delivered")
+
+	before := len(srv.Commands())
+	var buf bytes.Buffer
+	_, _, err := s.RetrieveIOAt("BIG.SEQ", &buf, zftp.TypeAscii, 100)
+	if !errors.Is(err, zftp.ErrAsciiResumeUnsupported) {
+		t.Fatalf("err = %v, want ErrAsciiResumeUnsupported", err)
+	}
+	if after := srv.Commands(); len(after) != before {
+		t.Errorf("rejected ASCII resume sent control command(s): %v", after[before:])
+	}
+	if buf.Len() != 0 {
+		t.Errorf("wrote %d byte(s) on rejected ASCII resume, want 0", buf.Len())
+	}
+}
+
+// TestStoreIOAt_AsciiOffsetRejected verifies that an ASCII store with a byte
+// offset is rejected with ErrAsciiResumeUnsupported before any I/O: no control
+// command (REST/STOR/TYPE) may be sent and nothing may be stored on the server.
+func TestStoreIOAt_AsciiOffsetRejected(t *testing.T) {
+	s, srv := dialMock(t)
+
+	before := len(srv.Commands())
+	_, _, err := s.StoreIOAt("OUT.TXT", strings.NewReader("alpha\nbeta\n"), zftp.TypeAscii, 100)
+	if !errors.Is(err, zftp.ErrAsciiResumeUnsupported) {
+		t.Fatalf("err = %v, want ErrAsciiResumeUnsupported", err)
+	}
+	if after := srv.Commands(); len(after) != before {
+		t.Errorf("rejected ASCII resume sent control command(s): %v", after[before:])
+	}
+	if _, ok := srv.Stored("OUT.TXT"); ok {
+		t.Errorf("server stored data on a rejected ASCII resume")
+	}
+}
+
+// TestStoreIOAt_BinaryOffset is a regression guard: image/binary resume must keep
+// working — REST <n> is sent before STOR and the exact bytes are stored.
+func TestStoreIOAt_BinaryOffset(t *testing.T) {
+	s, srv := dialMock(t)
+	payload := []byte{0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x10}
+
+	n, _, err := s.StoreIOAt("BIG.BIN", bytes.NewReader(payload), zftp.TypeBinary, 2048)
+	if err != nil {
+		t.Fatalf("StoreIOAt: %v", err)
+	}
+	if !hasCmd(srv.Commands(), "REST 2048") {
+		t.Errorf("expected REST 2048 in command sequence; got %v", srv.Commands())
+	}
+	stored, ok := srv.Stored("BIG.BIN")
+	if !ok || !bytes.Equal(stored, payload) {
+		t.Fatalf("stored = % x (ok=%v), want % x", stored, ok, payload)
+	}
+	if n != int64(len(payload)) {
+		t.Errorf("n = %d, want %d", n, len(payload))
 	}
 }


### PR DESCRIPTION
Closes #51

## Problem
`RetrieveIOAt`/`StoreIOAt` (and `GetAt`/`PutAt`) accepted `TypeAscii` together with `offset > 0` and issued `REST <byteoffset>` before `RETR`/`STOR`. A REST argument is a byte position that only maps to a stable remote location in image/binary mode; in TYPE A the server translates end-of-line and codepage, so a byte offset slices mid-record and **silently corrupts** the resumed data. `PutAt` was doubly wrong — it also seeked the local source to the offset. Nothing rejected the combination.

## Fix
- New sentinel `ErrAsciiResumeUnsupported`.
- Shared `guardResume(t, offset)` helper returns it when `offset > 0 && t.IsAscii()`, so the rule lives in one place.
- Called at the top of `RetrieveIOAt`, `StoreIOAt` (transfer.go), `GetAt` (get.go), `PutAt` (put.go) — **before any local-file or network I/O**. The rejected path has no side effects: `GetAt` does not create/open/truncate the local file; `PutAt` does not open or seek the source, nor send SITE/REST.
- Image/binary resume (`offset > 0`) is unchanged.
- Documented on the `*At` methods that resume requires image mode.

## Tests (TDD, RED→GREEN, under -race)
- `TestRetrieveIOAt_AsciiOffsetRejected`, `TestStoreIOAt_AsciiOffsetRejected`: return the sentinel and send **zero** control commands (snapshot of `Commands()` unchanged); nothing written/stored.
- `TestGetAt_AsciiOffsetRejected_LocalUntouched`: errors before the local file is created.
- `TestPutAt_AsciiOffsetRejected_BeforeOpen`: pointing at a non-existent source still returns the sentinel (proves the guard precedes `os.Open`).
- Regression: `TestRetrieveIOAt_Offset` and `TestStoreIOAt_BinaryOffset` confirm binary resume still sends `REST <n>` and transfers the exact bytes.

## Gate (local, all green under -race)
`CGO_ENABLED=0 go build ./...` · `go vet ./...` · `staticcheck ./...` · `go test -race ./...` · `govulncheck ./...`