### PR TITLE
fix: Lrecl() returns the LRECL, not the Blocksize

### DIFF
--- a/status_get.go
+++ b/status_get.go
@@ -336,7 +336,8 @@ func (s *ServerStatus) Lrecl() (int, error) {
 	if len(m) < 4 {
 		return 0, fmt.Errorf("could not parse Lrecl: %s", resp)
 	}
-	return strconv.Atoi(m[3])
+	// recFmt groups: m[1]=Recfm, m[2]=Lrecl, m[3]=Blocksize.
+	return strconv.Atoi(m[2])
 }
 
 func (s *ServerStatus) MBDataConn() (string, error) {

--- a/status_test.go
+++ b/status_test.go
@@ -31,6 +31,34 @@ func TestServerStatus_BlockSize(t *testing.T) {
 	}
 }
 
+func TestServerStatus_Lrecl(t *testing.T) {
+	s, srv := dialMock(t)
+	// Distinct Lrecl (80) and Blocksize (27920) so a getter that returns the
+	// wrong capture group of the shared recFmt regex is visible. A real z/OS
+	// XSTA status reply is multiline (211-... continuation, 211 terminator).
+	const recLine = "211-Record format FB, Lrecl: 80, Blocksize: 27920"
+	srv.Script("XSTA (Lrecl", recLine, "211 *** end of status ***")
+	srv.Script("XSTA (BLOCKSIze", recLine, "211 *** end of status ***")
+
+	lrecl, err := s.StatusOf().Lrecl()
+	if err != nil {
+		t.Fatalf("Lrecl: %v", err)
+	}
+	if lrecl != 80 {
+		t.Errorf("Lrecl = %d, want 80 (returning the Blocksize is the bug)", lrecl)
+	}
+
+	// Guard against a "fix" that merely swaps the two capture groups: BlockSize
+	// must still report the Blocksize from the same reply shape.
+	bs, err := s.StatusOf().BlockSize()
+	if err != nil {
+		t.Fatalf("BlockSize: %v", err)
+	}
+	if bs != 27920 {
+		t.Errorf("BlockSize = %d, want 27920", bs)
+	}
+}
+
 func TestServerStatus_FileType(t *testing.T) {
 	s, srv := dialMock(t)
 	srv.Script("XSTA (FileType",


### PR DESCRIPTION
Closes #53

## Problem (ZH05, P0)

`ServerStatus.Lrecl()` parses the shared record-format regex

```
recFmt = ^Record\s+format\s+(\w+)\s*,\s*Lrecl:\s*(\d+)\s*,\s*Blocksize:\s*(\d+)
```

whose capture groups are `m[1]=Recfm`, `m[2]=Lrecl`, `m[3]=Blocksize`. The
getter returned `strconv.Atoi(m[3])` — the **Blocksize** — so every caller
asking for the logical record length silently got the block size instead.

## Fix

Return `m[2]` (the Lrecl). One-line change.

Sibling getters that share `recFmt` are correct and left unchanged:
`BlockSize()` returns `m[3]` (Blocksize), `Recfm()` returns `m[1]` (format).

## Test (TDD, RED→GREEN, `-race`)

`TestServerStatus_Lrecl` scripts a multiline z/OS XSTA reply with **distinct**
Lrecl (80) and Blocksize (27920) via the in-process `mockzos` server, then:

- asserts `Lrecl() == 80` — RED before the fix (returned 27920, the Blocksize),
- asserts `BlockSize() == 27920` against the same reply shape, guarding against
  a "fix" that merely swaps the two capture groups.

## Verification (all green, under `-race`)

- `CGO_ENABLED=0 go build ./...`
- `CGO_ENABLED=0 go vet ./...`
- `staticcheck ./...` — no findings
- `go test -race ./...`
- `govulncheck ./...` — no vulnerabilities