### PR TITLE
fix: make log levels independent bit flags (ZH06)

### DIFF
--- a/internal/log/logger.go
+++ b/internal/log/logger.go
@@ -28,14 +28,21 @@ type Logger interface {
 
 type Level uint32
 
+// None disables every logging category.
+const None Level = 0
+
+// The four logging categories are independent, single-bit flags: combine them
+// with OR and test membership with IsEnabled. Each occupies a distinct bit, so
+// enabling one category never implies another.
 const (
-	None Level = iota << 1
-	ServerLevel
-	PassiveLevel
-	CommandLevel
-	DebugLevel
-	All = ServerLevel | PassiveLevel | CommandLevel | DebugLevel
+	ServerLevel  Level = 1 << iota // 1 — server replies
+	PassiveLevel                   // 2 — passive-mode negotiation
+	CommandLevel                   // 4 — commands sent
+	DebugLevel                     // 8 — verbose debug
 )
+
+// All enables every logging category.
+const All = ServerLevel | PassiveLevel | CommandLevel | DebugLevel
 
 type logger struct {
 	level atomic.Uint32

--- a/internal/log/logger_test.go
+++ b/internal/log/logger_test.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package log
+
+import (
+	"math/bits"
+	"testing"
+)
+
+// flags lists the four independent logging categories. None and All are derived
+// from these, so the tests assert their relationship rather than listing them.
+var flags = []Level{ServerLevel, PassiveLevel, CommandLevel, DebugLevel}
+
+// restoreLevel snapshots the package singleton's level and restores it when the
+// test finishes. The logger is a process-wide singleton, so without this the
+// cases below would leak state into one another (and into the rest of the
+// package's tests).
+func restoreLevel(t *testing.T) {
+	t.Helper()
+	saved := Level(std.level.Load())
+	t.Cleanup(func() { std.level.Store(uint32(saved)) })
+}
+
+// TestLevelsAreDistinctSingleBits is the core ZH06 guard: each category must own
+// a single, distinct bit. The original `iota << 1` block produced 2/4/6/8, so
+// CommandLevel(6) == ServerLevel(2)|PassiveLevel(4) and the bitmask checks in
+// IsEnabled bled across categories.
+func TestLevelsAreDistinctSingleBits(t *testing.T) {
+	for _, l := range flags {
+		if got := bits.OnesCount32(uint32(l)); got != 1 {
+			t.Errorf("level %d must be a single bit, has %d bits set", l, got)
+		}
+	}
+
+	union := ServerLevel | PassiveLevel | CommandLevel | DebugLevel
+	if got := bits.OnesCount32(uint32(union)); got != 4 {
+		t.Errorf("union of the four levels must occupy 4 distinct bits, has %d (union=%d)", got, union)
+	}
+
+	for i := 0; i < len(flags); i++ {
+		for j := i + 1; j < len(flags); j++ {
+			if flags[i]&flags[j] != 0 {
+				t.Errorf("levels %d and %d overlap (AND=%d)", flags[i], flags[j], flags[i]&flags[j])
+			}
+		}
+	}
+}
+
+func TestNoneIsZero(t *testing.T) {
+	if None != 0 {
+		t.Errorf("None must be 0, got %d", None)
+	}
+}
+
+func TestAllIsUnionOfTheFourLevels(t *testing.T) {
+	want := ServerLevel | PassiveLevel | CommandLevel | DebugLevel
+	if All != want {
+		t.Errorf("All must equal the OR of the four levels (%d), got %d", want, All)
+	}
+}
+
+// TestSetCommandEnablesOnlyCommand pins the user-visible symptom: selecting one
+// category must not silently switch on its neighbours.
+func TestSetCommandEnablesOnlyCommand(t *testing.T) {
+	restoreLevel(t)
+	SetLevel(CommandLevel)
+
+	if !IsEnabled(CommandLevel) {
+		t.Error("CommandLevel must be enabled after SetLevel(CommandLevel)")
+	}
+	for _, l := range []Level{ServerLevel, PassiveLevel, DebugLevel} {
+		if IsEnabled(l) {
+			t.Errorf("level %d must NOT be enabled by SetLevel(CommandLevel)", l)
+		}
+	}
+}
+
+func TestSetDebugEnablesOnlyDebug(t *testing.T) {
+	restoreLevel(t)
+	SetLevel(DebugLevel)
+
+	if !IsEnabled(DebugLevel) {
+		t.Error("DebugLevel must be enabled after SetLevel(DebugLevel)")
+	}
+	for _, l := range []Level{ServerLevel, PassiveLevel, CommandLevel} {
+		if IsEnabled(l) {
+			t.Errorf("level %d must NOT be enabled by SetLevel(DebugLevel)", l)
+		}
+	}
+}
+
+func TestSetAllEnablesEveryLevel(t *testing.T) {
+	restoreLevel(t)
+	SetLevel(All)
+
+	for _, l := range flags {
+		if !IsEnabled(l) {
+			t.Errorf("level %d must be enabled after SetLevel(All)", l)
+		}
+	}
+}
+
+func TestSetNoneDisablesEveryLevel(t *testing.T) {
+	restoreLevel(t)
+	SetLevel(None)
+
+	for _, l := range flags {
+		if IsEnabled(l) {
+			t.Errorf("level %d must be disabled after SetLevel(None)", l)
+		}
+	}
+}

--- a/log.go
+++ b/log.go
@@ -4,13 +4,22 @@ package zftp
 
 import "gopkg.in/ro-ag/zftp.v2/internal/log"
 
+// LogLevel is a bitmask selecting which categories SetVerbose enables. Its bit
+// values mirror internal/log.Level exactly, so SetVerbose's cast is
+// value-preserving; combine flags with OR.
 type LogLevel log.Level
 
+// NoLog disables every logging category.
+const NoLog LogLevel = 0
+
+// The four logging categories are independent, single-bit flags: enabling one
+// never implies another. Combine them with OR (or use LogAll).
 const (
-	NoLog LogLevel = iota << 1
-	LogServer
-	LogPassive
-	LogCommand
-	LogDebug
-	LogAll = LogServer | LogPassive | LogCommand | LogDebug
+	LogServer  LogLevel = 1 << iota // 1 — server replies
+	LogPassive                      // 2 — passive-mode negotiation
+	LogCommand                      // 4 — commands sent
+	LogDebug                        // 8 — verbose debug
 )
+
+// LogAll enables every logging category.
+const LogAll = LogServer | LogPassive | LogCommand | LogDebug

--- a/log_test.go
+++ b/log_test.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package zftp
+
+import (
+	"testing"
+
+	"gopkg.in/ro-ag/zftp.v2/internal/log"
+)
+
+// TestLogLevelMirrorsInternal guards the invariant that the public LogLevel
+// constants carry the exact bit values of internal/log.Level. SetVerbose maps
+// one onto the other with a plain cast (log.SetLevel(log.Level(level))), so any
+// drift between the two blocks would silently mis-route logging categories.
+func TestLogLevelMirrorsInternal(t *testing.T) {
+	cases := []struct {
+		name     string
+		public   LogLevel
+		internal log.Level
+	}{
+		{"NoLog/None", NoLog, log.None},
+		{"LogServer/ServerLevel", LogServer, log.ServerLevel},
+		{"LogPassive/PassiveLevel", LogPassive, log.PassiveLevel},
+		{"LogCommand/CommandLevel", LogCommand, log.CommandLevel},
+		{"LogDebug/DebugLevel", LogDebug, log.DebugLevel},
+		{"LogAll/All", LogAll, log.All},
+	}
+
+	for _, c := range cases {
+		// Values must match...
+		if uint32(c.public) != uint32(c.internal) {
+			t.Errorf("%s: public=%d internal=%d — values must match", c.name, uint32(c.public), uint32(c.internal))
+		}
+		// ...and the cast SetVerbose performs must be value-preserving.
+		if log.Level(c.public) != c.internal {
+			t.Errorf("%s: log.Level(public)=%d != internal=%d", c.name, log.Level(c.public), c.internal)
+		}
+	}
+}


### PR DESCRIPTION
Closes #55

## Problem
`LogLevel` (`log.go`) and `internal/log.Level` both used `iota << 1`, giving `None=0, Server=2, Passive=4, Command=6, Debug=8`. `IsEnabled` treats the value as a bitmask, but `6 == 2|4`, so `CommandLevel == ServerLevel|PassiveLevel`: selecting Command silently enabled Server and Passive, `DebugLevel` (8) excluded Command, and only `All` (14) worked by accident.

## Fix
Distinct single bits via `1 << iota`: `None/NoLog = 0`, `1/2/4/8` for Server/Passive/Command/Debug, `All/LogAll = 15`. Both blocks keep identical values, so `SetVerbose`'s `log.Level(level)` cast stays value-preserving.

Numeric constant values change — a behavior fix, not a source break (callers use the named constants). v2 is unreleased, so this is approved.

## Tests (TDD, RED->GREEN, under `-race`)
- `internal/log/logger_test.go` (new, white-box): the four flags are distinct powers of two with no pairwise overlap; `SetLevel(CommandLevel)` enables only Command (RED under the old values); Debug/All/None isolation; restores the singleton level via `t.Cleanup`.
- `log_test.go` (new): guards that the public `LogLevel` constants mirror `internal/log.Level` bit-for-bit, so the two cannot drift again.

## Verification (local, all green)
- `CGO_ENABLED=0 go build ./...`
- `CGO_ENABLED=0 go vet ./...`
- `staticcheck ./...`
- `go test -race ./...`
- `govulncheck ./...` — No vulnerabilities found