### PR TITLE
feat: per-session slog logger injection (WithLogger / SetLogger)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        go: ["1.20", "stable"]
+        go: ["1.21", "stable"]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        go: ["1.21", "stable"]
+        go: ["1.26", "stable"]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/Readme.md
+++ b/Readme.md
@@ -78,7 +78,7 @@ A compile-checked version of this snippet lives in
 
 - `Open(address string, opts ...Option) (*FTPSession, error)` — open a session
   to `host:port`. Options include `WithTimeout`, `WithKeepAlive`, `WithDialer`,
-  and `WithSignalHandler`.
+  `WithSignalHandler`, and `WithLogger` (see [Logging](#logging)).
 - `(*FTPSession) Login(user, pass string) error`
 - `(*FTPSession) Get(remote, local string, mode TransferType) error` /
   `Put(local, remote string, mode TransferType, a ...DataSpec) error`
@@ -93,6 +93,46 @@ A compile-checked version of this snippet lives in
   retrieve and gzip in one step.
 
 Full reference: [pkg.go.dev/gopkg.in/ro-ag/zftp.v2](https://pkg.go.dev/gopkg.in/ro-ag/zftp.v2).
+
+## Logging
+
+zftp logs through the standard library's [`log/slog`](https://pkg.go.dev/log/slog).
+Logging is **per session** and **silent by default** — nothing is emitted until you
+opt in with `SetVerbose`.
+
+`SetVerbose` selects which trace categories a session emits: a bitmask of
+`LogServer`, `LogPassive`, `LogCommand`, `LogDebug` (or `LogAll`; `NoLog` disables
+them). Route the records into your own logger with `WithLogger` at open time, or
+`SetLogger` at runtime:
+
+```go
+h := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug})
+s, err := zftp.Open("host:21", zftp.WithLogger(slog.New(h)))
+// ...
+s.SetVerbose(zftp.LogCommand | zftp.LogServer)
+```
+
+With no `WithLogger`, zftp falls back to `slog.Default()`.
+
+**Record shape.** Every record carries `component=zftp`. The four trace categories
+are emitted at `slog.LevelDebug` with a `category` attribute
+(`server`/`passive`/`command`/`debug`); warnings at `slog.LevelWarn` and errors at
+`slog.LevelError`. Your handler's own level still applies on top of `SetVerbose`, so
+a handler set to `LevelInfo` drops the trace lines while keeping warnings and errors.
+
+**Bringing your own logger (zap, zerolog).** The core depends only on `log/slog`, so
+any logger that exposes a `slog.Handler` plugs in — the bridge package lives in your
+application's `go.mod`, and zftp stays dependency-free:
+
+```go
+// zap — via a zap→slog handler (go.uber.org/zap/exp/zapslog)
+s, _ := zftp.Open(addr, zftp.WithLogger(slog.New(zapHandler)))     // zapHandler is a slog.Handler
+
+// zerolog — via a zerolog→slog handler (e.g. samber/slog-zerolog)
+s, _ := zftp.Open(addr, zftp.WithLogger(slog.New(zerologHandler))) // zerologHandler is a slog.Handler
+```
+
+Check each bridge's current release for its exact handler constructor.
 
 ## Testing without a mainframe
 

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,6 +1,6 @@
 module github.com/ro-ag/zftp/cli
 
-go 1.21
+go 1.26
 
 require gopkg.in/ro-ag/zftp.v2 v2.0.0
 

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,6 +1,6 @@
 module github.com/ro-ag/zftp/cli
 
-go 1.20
+go 1.21
 
 require gopkg.in/ro-ag/zftp.v2 v2.0.0
 

--- a/cmd.go
+++ b/cmd.go
@@ -59,7 +59,7 @@ func (s *FTPSession) sendLocked(ctx context.Context, expect ReturnCode, command 
 		return "", fmt.Errorf("zftp: control connection write failed, session closed: %w", err)
 	}
 
-	msg, err := expect.check(reader)
+	msg, err := expect.check(reader, s.log)
 	if err != nil {
 		s.log.Serverf("error %s", err)
 		var re *ReturnError
@@ -136,7 +136,7 @@ func (s *FTPSession) checkLast(expect ReturnCode) (string, error) {
 
 	s.lastMessage.Reset()
 
-	msg, err := expect.check(s.reader)
+	msg, err := expect.check(s.reader, s.log)
 
 	s.lastMessage.WriteString(msg)
 

--- a/cmd.go
+++ b/cmd.go
@@ -43,7 +43,7 @@ func (s *FTPSession) sendLocked(ctx context.Context, expect ReturnCode, command 
 	}
 
 	conn, reader := s.conn, s.reader
-	fullCommand := parseCommand(command, a...)
+	fullCommand := parseCommand(s.log, command, a...)
 
 	if dl, ok := ctx.Deadline(); ok {
 		if err := conn.SetDeadline(dl); err != nil {
@@ -54,14 +54,14 @@ func (s *FTPSession) sendLocked(ctx context.Context, expect ReturnCode, command 
 
 	// log has already been printed in parseCommand
 	if _, err := conn.Write(fullCommand); err != nil {
-		log.Commandf("error %s", err)
+		s.log.Commandf("error %s", err)
 		s.closeLocked()
 		return "", fmt.Errorf("zftp: control connection write failed, session closed: %w", err)
 	}
 
 	msg, err := expect.check(reader)
 	if err != nil {
-		log.Serverf("error %s", err)
+		s.log.Serverf("error %s", err)
 		var re *ReturnError
 		if errors.As(err, &re) {
 			// Reply read in full but with an unexpected (yet valid) FTP code; the
@@ -81,7 +81,7 @@ func (s *FTPSession) sendLocked(ctx context.Context, expect ReturnCode, command 
 }
 
 // parseCommand parses a command and its arguments into a byte slice.
-func parseCommand(cmd string, a ...string) []byte {
+func parseCommand(lg *log.Logger, cmd string, a ...string) []byte {
 
 	var (
 		command = strings.TrimSpace(strings.ToUpper(cmd))
@@ -91,11 +91,11 @@ func parseCommand(cmd string, a ...string) []byte {
 	switch {
 	case strings.HasPrefix(command, "PASS"):
 		maskPassword := strings.Repeat("*", len(args))
-		log.Commandf("PASS %s", maskPassword)
+		lg.Commandf("PASS %s", maskPassword)
 	case len(a) > 0:
-		log.Commandf("%s %s", command, args)
+		lg.Commandf("%s %s", command, args)
 	default:
-		log.Commandf("%s", command)
+		lg.Commandf("%s", command)
 	}
 
 	fullCommand := []byte(fmt.Sprintf("%s %s\r\n", command, args))
@@ -121,7 +121,7 @@ func (s *FTPSession) checkLast(expect ReturnCode) (string, error) {
 	defer s.mu.Unlock()
 
 	if s.isClosed.Load() {
-		log.Warningf("<%s> session %s is closed", utils.Caller(), s.conn.RemoteAddr().String())
+		s.log.Warningf("<%s> session %s is closed", utils.Caller(), s.conn.RemoteAddr().String())
 		return "", nil
 	}
 
@@ -141,7 +141,7 @@ func (s *FTPSession) checkLast(expect ReturnCode) (string, error) {
 	s.lastMessage.WriteString(msg)
 
 	if err != nil {
-		log.Serverf("[res|error] %s", err)
+		s.log.Serverf("[res|error] %s", err)
 		var re *ReturnError
 		if !errors.As(err, &re) {
 			// I/O-level failure on the post-transfer reply read: like sendLocked,

--- a/codes.go
+++ b/codes.go
@@ -86,7 +86,7 @@ func (e *ReturnError) Error() string {
 // opening code keeps such replies whole and the control stream in sync for the
 // next command. Every line is appended (including lines shorter than 4 bytes) so
 // no reply text is lost.
-func (code ReturnCode) check(reader *bufio.Reader) (msg string, err error) {
+func (code ReturnCode) check(reader *bufio.Reader, lg *log.Logger) (msg string, err error) {
 
 	var (
 		response    strings.Builder
@@ -112,7 +112,7 @@ func (code ReturnCode) check(reader *bufio.Reader) (msg string, err error) {
 			return "", err
 		}
 
-		log.Serverf("%s", line)
+		lg.Serverf("%s", line)
 
 		// Parse the leading 3-digit code when the line is long enough to carry
 		// one. The first line that parses fixes the reply's opening code.
@@ -120,7 +120,7 @@ func (code ReturnCode) check(reader *bufio.Reader) (msg string, err error) {
 		haveLineCode := false
 		if len(line) >= 4 {
 			if c, atoiErr := strconv.Atoi(string(line[:3])); atoiErr != nil {
-				log.Errorf("converting response code to integer: %s", atoiErr)
+				lg.Errorf("converting response code to integer: %s", atoiErr)
 			} else {
 				lineCode = c
 				haveLineCode = true

--- a/docs/superpowers/plans/2026-06-22-logger-injection.md
+++ b/docs/superpowers/plans/2026-06-22-logger-injection.md
@@ -1,0 +1,680 @@
+# Logger Injection (per-session slog) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let callers inject a `*slog.Logger` per `FTPSession` so zftp logs route into slog/zap/zerolog, with zero third-party deps in core.
+
+**Architecture:** Rewrite `internal/log` from a global singleton into a `Logger` value type that applies the category bitmask prefilter and emits structured `slog` records. Each `*FTPSession` owns one. Transitional package-level shims keep the build green while ~60 call sites migrate file-by-file; the shims are deleted at the end.
+
+**Tech Stack:** Go 1.21+ (`log/slog`), `internal/mockzos` loopback for tests.
+
+## Global Constraints
+
+- **Go floor:** `go 1.21` in `go.mod`; CI matrix `["1.21","stable"]`. (slog is stdlib from 1.21.)
+- **Zero third-party deps in core.** Only stdlib (incl. `log/slog`). zap/zerolog bridge in the user's app.
+- **SPDX header** `// SPDX-License-Identifier: Apache-2.0` on every `.go` file (first line).
+- **Errors:** `errors.New` for static sentinels, `%w` for wraps.
+- **Commits/PR:** NO `Co-Authored-By` and NO "Generated with Claude"/AI attribution. Branch `feat/logger-injection` off `main`; one PR.
+- **Gate before done (show output):** `CGO_ENABLED=0 go build ./...`, `CGO_ENABLED=0 go vet ./...`, `staticcheck ./...`, `go test -race ./...`, `govulncheck ./...`; CI green.
+- **ZH06 bit values are load-bearing:** `None=0, ServerLevel=1, PassiveLevel=2, CommandLevel=4, DebugLevel=8, All=15`. Public `LogLevel` must keep identical values (`SetVerbose` casts `log.Level(level)`).
+
+---
+
+### Task 1: Bump Go floor to 1.21
+
+**Files:**
+- Modify: `go.mod:3`
+- Modify: `.github/workflows/*.yml` (the matrix line `go: ["1.20", "stable"]`)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `log/slog` available to all later tasks.
+
+- [ ] **Step 1: Edit go.mod**
+
+Change `go 1.20` → `go 1.21`.
+
+- [ ] **Step 2: Edit CI matrix**
+
+In the workflow file with `go: ["1.20", "stable"]`, change to `go: ["1.21", "stable"]`.
+
+- [ ] **Step 3: Verify build**
+
+Run: `CGO_ENABLED=0 go build ./...`
+Expected: success, no output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add go.mod .github/workflows
+git commit -m "build: require Go 1.21 (log/slog)"
+```
+
+---
+
+### Task 2: Rewrite internal/log as a Logger value type (+ transitional shims)
+
+Rewrite the package: a `Logger` struct emitting `slog` records, reusing the ZH06 `Level` bits, plus package-level shims (same names/signatures as today) so existing call sites compile unchanged. TDD the struct.
+
+**Files:**
+- Modify (full rewrite): `internal/log/logger.go`
+- Modify (extend): `internal/log/logger_test.go`
+
+**Interfaces:**
+- Consumes: `log/slog` (Task 1).
+- Produces:
+  - `type Level uint32` with `None=0, ServerLevel=1, PassiveLevel=2, CommandLevel=4, DebugLevel=8, All=15`.
+  - `type Logger struct{…}`; `func New(l *slog.Logger, lvl Level) *Logger`.
+  - Methods: `SetSlog(*slog.Logger)`, `SetLevel(Level)`, `Level() Level`, and emitters `Command/Commandf/Server/Serverf/Passive/Passivef/Debug/Debugf/Warning/Warningf/Error/Errorf` (each `(v ...any)` / `(format string, v ...any)`).
+  - Transitional package funcs (same names) delegating to a package default `std *Logger`: `SetLevel`, `Debug/Debugf/Command/Commandf/Passive/Passivef/Server/Serverf/Warning/Warningf/Error/Errorf`.
+
+- [ ] **Step 1: Write the failing tests** (extend `internal/log/logger_test.go`)
+
+Add a capturing handler and behavior tests. KEEP the existing ZH06 tests (`TestLevelsAreDistinctSingleBits`, etc.) unchanged.
+
+```go
+// capture is a slog.Handler that records every record it is asked to handle.
+type capture struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (c *capture) Enabled(context.Context, slog.Level) bool { return true }
+func (c *capture) Handle(_ context.Context, r slog.Record) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.records = append(c.records, r.Clone())
+	return nil
+}
+func (c *capture) WithAttrs(attrs []slog.Attr) slog.Handler { return c }
+func (c *capture) WithGroup(string) slog.Handler            { return c }
+
+func (c *capture) snapshot() []slog.Record {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]slog.Record(nil), c.records...)
+}
+
+// attrMap collects a record's attributes into a map for assertions.
+func attrMap(r slog.Record) map[string]string {
+	m := map[string]string{}
+	r.Attrs(func(a slog.Attr) bool { m[a.Key] = a.Value.String(); return true })
+	return m
+}
+
+func TestLogger_PrefilterEmitsOnlyEnabledCategory(t *testing.T) {
+	cap := &capture{}
+	lg := New(slog.New(cap), CommandLevel)
+
+	lg.Commandf("PASS %s", "secret")
+	lg.Serverf("220 ready")  // ServerLevel not enabled
+	lg.Passivef("227 ...")   // PassiveLevel not enabled
+	lg.Debugf("trace")       // DebugLevel not enabled
+
+	recs := cap.snapshot()
+	if len(recs) != 1 {
+		t.Fatalf("want exactly 1 record (command only), got %d", len(recs))
+	}
+	if recs[0].Level != slog.LevelDebug {
+		t.Errorf("command should map to LevelDebug, got %v", recs[0].Level)
+	}
+	m := attrMap(recs[0])
+	if m["category"] != "command" {
+		t.Errorf(`want category="command", got %q`, m["category"])
+	}
+	if m["component"] != "zftp" {
+		t.Errorf(`want component="zftp", got %q`, m["component"])
+	}
+	if recs[0].Message != "PASS secret" {
+		t.Errorf("unexpected message %q", recs[0].Message)
+	}
+}
+
+func TestLogger_WarningAndErrorAlwaysEmit(t *testing.T) {
+	cap := &capture{}
+	lg := New(slog.New(cap), None) // nothing in the trace bitmask
+
+	lg.Warningf("w")
+	lg.Errorf("e")
+
+	recs := cap.snapshot()
+	if len(recs) != 2 {
+		t.Fatalf("warning+error must emit regardless of level, got %d", len(recs))
+	}
+	if recs[0].Level != slog.LevelWarn || recs[1].Level != slog.LevelError {
+		t.Errorf("levels: got %v, %v want Warn, Error", recs[0].Level, recs[1].Level)
+	}
+	if attrMap(recs[0])["component"] != "zftp" {
+		t.Error("warning record missing component=zftp")
+	}
+}
+
+func TestLogger_SourcePointsAtCallSite(t *testing.T) {
+	cap := &capture{}
+	lg := New(slog.New(cap), DebugLevel)
+
+	lg.Debugf("x") ; wantLine := 0 // placeholder; set below
+	_ = wantLine
+
+	recs := cap.snapshot()
+	if len(recs) != 1 {
+		t.Fatalf("want 1 record, got %d", len(recs))
+	}
+	fs := runtime.CallersFrames([]uintptr{recs[0].PC})
+	f, _ := fs.Next()
+	if !strings.HasSuffix(f.File, "logger_test.go") {
+		t.Errorf("source should be the call site (logger_test.go), got %s:%d", f.File, f.Line)
+	}
+}
+
+func TestLogger_NilSlogUsesDefault(t *testing.T) {
+	cap := &capture{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(cap))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	lg := New(nil, DebugLevel) // nil ⇒ lazy slog.Default()
+	lg.Debugf("via default")
+
+	if len(cap.snapshot()) != 1 {
+		t.Fatal("nil logger should route to slog.Default()")
+	}
+}
+
+func TestLogger_ConcurrentSwapRace(t *testing.T) {
+	lg := New(slog.New(&capture{}), All)
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				lg.Commandf("c%d", j)
+				lg.SetLevel(All)
+				lg.SetSlog(slog.New(&capture{}))
+			}
+		}()
+	}
+	wg.Wait()
+}
+```
+
+Add imports: `context`, `log/slog`, `runtime`, `strings`, `sync` (plus existing `math/bits`, `testing`).
+
+> Note for the `TestLogger_SourcePointsAtCallSite` body: delete the placeholder
+> lines; just call `lg.Debugf("x")` then assert. (Shown verbosely to make the
+> intent explicit.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/log/ -run 'TestLogger_' -v`
+Expected: FAIL — `New`, `*Logger` methods undefined.
+
+- [ ] **Step 3: Write the implementation** (full file replace `internal/log/logger.go`)
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package log
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"runtime"
+	"sync/atomic"
+	"time"
+)
+
+// Level is a bitmask of independent logging categories; combine with OR and test
+// membership via the category emitters. Each flag is a distinct bit, so enabling
+// one category never implies another.
+type Level uint32
+
+// None disables every logging category.
+const None Level = 0
+
+const (
+	ServerLevel  Level = 1 << iota // 1 — server replies
+	PassiveLevel                   // 2 — passive-mode negotiation
+	CommandLevel                   // 4 — commands sent
+	DebugLevel                     // 8 — verbose debug
+)
+
+// All enables every logging category.
+const All = ServerLevel | PassiveLevel | CommandLevel | DebugLevel
+
+// component tags every zftp record so it is greppable in a shared log stream.
+const component = "zftp"
+
+var (
+	catCommand = slog.String("category", "command")
+	catServer  = slog.String("category", "server")
+	catPassive = slog.String("category", "passive")
+	catDebug   = slog.String("category", "debug")
+)
+
+// Logger applies the category bitmask prefilter and emits structured slog records.
+// The zero value is not usable; construct with New. Safe for concurrent use.
+type Logger struct {
+	base  atomic.Pointer[slog.Logger] // nil ⇒ resolve slog.Default() lazily at emit
+	level atomic.Uint32               // category bitmask
+}
+
+// New returns a Logger emitting to l at the given category level. A nil l selects
+// slog.Default() at emit time (honoring a later slog.SetDefault).
+func New(l *slog.Logger, lvl Level) *Logger {
+	lg := &Logger{}
+	lg.SetSlog(l)
+	lg.SetLevel(lvl)
+	return lg
+}
+
+// SetSlog swaps the destination logger. A nil s reverts to the lazy slog.Default().
+func (l *Logger) SetSlog(s *slog.Logger) {
+	if s == nil {
+		l.base.Store(nil)
+		return
+	}
+	l.base.Store(tagged(s))
+}
+
+// SetLevel replaces the category bitmask.
+func (l *Logger) SetLevel(lvl Level) { l.level.Store(uint32(lvl)) }
+
+// Level returns the current category bitmask.
+func (l *Logger) Level() Level { return Level(l.level.Load()) }
+
+func (l *Logger) enabled(cat Level) bool { return l.level.Load()&uint32(cat) != 0 }
+
+// tagged derives a logger carrying the stable component attribute (applied once).
+func tagged(s *slog.Logger) *slog.Logger {
+	return s.With(slog.String("component", component))
+}
+
+// resolve returns the destination logger, tagging the lazy default when no logger
+// was injected.
+func (l *Logger) resolve() *slog.Logger {
+	if b := l.base.Load(); b != nil {
+		return b
+	}
+	return tagged(slog.Default())
+}
+
+// emit builds a record with the caller's source location and dispatches it.
+func (l *Logger) emit(level slog.Level, msg string, attrs ...slog.Attr) {
+	base := l.resolve()
+	ctx := context.Background()
+	if !base.Enabled(ctx, level) {
+		return
+	}
+	var pcs [1]uintptr
+	runtime.Callers(3, pcs[:]) // skip [Callers, emit, category method] → real call site
+	r := slog.NewRecord(time.Now(), level, msg, pcs[0])
+	r.AddAttrs(attrs...)
+	_ = base.Handler().Handle(ctx, r)
+}
+
+func (l *Logger) Command(v ...any)            { if l.enabled(CommandLevel) { l.emit(slog.LevelDebug, fmt.Sprint(v...), catCommand) } }
+func (l *Logger) Commandf(f string, v ...any) { if l.enabled(CommandLevel) { l.emit(slog.LevelDebug, fmt.Sprintf(f, v...), catCommand) } }
+func (l *Logger) Server(v ...any)             { if l.enabled(ServerLevel) { l.emit(slog.LevelDebug, fmt.Sprint(v...), catServer) } }
+func (l *Logger) Serverf(f string, v ...any)  { if l.enabled(ServerLevel) { l.emit(slog.LevelDebug, fmt.Sprintf(f, v...), catServer) } }
+func (l *Logger) Passive(v ...any)            { if l.enabled(PassiveLevel) { l.emit(slog.LevelDebug, fmt.Sprint(v...), catPassive) } }
+func (l *Logger) Passivef(f string, v ...any) { if l.enabled(PassiveLevel) { l.emit(slog.LevelDebug, fmt.Sprintf(f, v...), catPassive) } }
+func (l *Logger) Debug(v ...any)              { if l.enabled(DebugLevel) { l.emit(slog.LevelDebug, fmt.Sprint(v...), catDebug) } }
+func (l *Logger) Debugf(f string, v ...any)   { if l.enabled(DebugLevel) { l.emit(slog.LevelDebug, fmt.Sprintf(f, v...), catDebug) } }
+func (l *Logger) Warning(v ...any)            { l.emit(slog.LevelWarn, fmt.Sprint(v...)) }
+func (l *Logger) Warningf(f string, v ...any) { l.emit(slog.LevelWarn, fmt.Sprintf(f, v...)) }
+func (l *Logger) Error(v ...any)              { l.emit(slog.LevelError, fmt.Sprint(v...)) }
+func (l *Logger) Errorf(f string, v ...any)   { l.emit(slog.LevelError, fmt.Sprintf(f, v...)) }
+
+// --- transitional package-level shims (removed in the final task once every call
+// site uses a *Logger). They delegate to a package default so existing call sites
+// compile unchanged during the migration. ---
+
+var std = New(nil, None)
+
+func SetLevel(lvl Level)          { std.SetLevel(lvl) }
+func Debug(v ...any)              { std.Debug(v...) }
+func Debugf(f string, v ...any)   { std.Debugf(f, v...) }
+func Command(v ...any)            { std.Command(v...) }
+func Commandf(f string, v ...any) { std.Commandf(f, v...) }
+func Passive(v ...any)            { std.Passive(v...) }
+func Passivef(f string, v ...any) { std.Passivef(f, v...) }
+func Server(v ...any)             { std.Server(v...) }
+func Serverf(f string, v ...any)  { std.Serverf(f, v...) }
+func Warning(v ...any)            { std.Warning(v...) }
+func Warningf(f string, v ...any) { std.Warningf(f, v...) }
+func Error(v ...any)              { std.Error(v...) }
+func Errorf(f string, v ...any)   { std.Errorf(f, v...) }
+```
+
+> The shims add one stack frame, so during migration a shim-routed record's source
+> points at the shim. This is transitional; direct `*Logger` calls (tests + migrated
+> sites) have correct source. The source test calls methods directly, so it passes now.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test -race ./internal/log/ -v`
+Expected: PASS (new `TestLogger_*` + existing ZH06 tests).
+
+- [ ] **Step 5: Verify the whole module still builds (shims keep call sites green)**
+
+Run: `CGO_ENABLED=0 go build ./... && CGO_ENABLED=0 go vet ./...`
+Expected: success.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/log/logger.go internal/log/logger_test.go
+git commit -m "feat(log): slog-backed per-instance Logger type (shims keep call sites green)"
+```
+
+---
+
+### Task 3: Wire a per-session logger + public WithLogger/SetLogger
+
+**Files:**
+- Modify: `options.go` (add `logger` to `dialOptions`; add `WithLogger`)
+- Modify: `ftp.go` (add `log` field; set it in `newSession`; `SetVerbose`→`s.log`; add `SetLogger`)
+- Modify: `log.go` (no value change; LogLevel stays — confirm it still casts)
+- Test: `log_test.go` (extend) + new `logger_session_test.go`
+
+**Interfaces:**
+- Consumes: `log.New`, `*log.Logger` methods (Task 2).
+- Produces:
+  - `func WithLogger(l *slog.Logger) Option`
+  - `(*FTPSession).SetLogger(l *slog.Logger)`
+  - `FTPSession.log *log.Logger` (unexported), always non-nil after `newSession`.
+
+- [ ] **Step 1: Write failing tests** (`logger_session_test.go`, package `zftp`)
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package zftp
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+
+	ilog "gopkg.in/ro-ag/zftp.v2/internal/log"
+)
+
+type capHandler struct {
+	mu   sync.Mutex
+	cats []string
+}
+
+func (c *capHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (c *capHandler) Handle(_ context.Context, r slog.Record) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	r.Attrs(func(a slog.Attr) bool {
+		if a.Key == "category" {
+			c.cats = append(c.cats, a.Value.String())
+		}
+		return true
+	})
+	return nil
+}
+func (c *capHandler) WithAttrs([]slog.Attr) slog.Handler { return c }
+func (c *capHandler) WithGroup(string) slog.Handler      { return c }
+func (c *capHandler) count() int { c.mu.Lock(); defer c.mu.Unlock(); return len(c.cats) }
+
+// Two sessions, different loggers and levels, must not cross-talk.
+func TestPerSessionLoggerIsolation(t *testing.T) {
+	a, b := &capHandler{}, &capHandler{}
+
+	s1 := newSession(nil, dialOptions{})
+	s1.SetLogger(slog.New(a))
+	s1.SetVerbose(LogCommand)
+
+	s2 := newSession(nil, dialOptions{})
+	s2.SetLogger(slog.New(b))
+	s2.SetVerbose(NoLog)
+
+	s1.log.Commandf("PASS x")
+	s2.log.Commandf("PASS y") // s2 has NoLog ⇒ suppressed
+
+	if a.count() != 1 {
+		t.Errorf("session 1 should have 1 command record, got %d", a.count())
+	}
+	if b.count() != 0 {
+		t.Errorf("session 2 (NoLog) should capture nothing, got %d", b.count())
+	}
+}
+
+// WithLogger wires the option through Open's construction path (newSession).
+func TestWithLoggerOption(t *testing.T) {
+	h := &capHandler{}
+	var cfg dialOptions
+	cfg.apply([]Option{WithLogger(slog.New(h))})
+	s := newSession(nil, cfg)
+	s.SetVerbose(LogServer)
+
+	s.log.Serverf("220 ready")
+	if h.count() != 1 {
+		t.Errorf("WithLogger should route Serverf to the handler, got %d", h.count())
+	}
+}
+
+// Default session (no WithLogger, no SetVerbose) is silent.
+func TestDefaultSessionSilent(t *testing.T) {
+	s := newSession(nil, dialOptions{})
+	if s.log == nil {
+		t.Fatal("session logger must be non-nil after newSession")
+	}
+	if s.log.Level() != ilog.None {
+		t.Errorf("default level should be None, got %d", s.log.Level())
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test . -run 'TestPerSessionLoggerIsolation|TestWithLoggerOption|TestDefaultSessionSilent' -v`
+Expected: FAIL — `SetLogger`, `WithLogger`, `s.log` undefined.
+
+- [ ] **Step 3: Implement**
+
+In `options.go`: add field + import `log/slog` + the internal log import, and the option.
+
+```go
+// dialOptions struct: add field
+	logger *slog.Logger
+```
+```go
+// WithLogger routes this session's logs into l. A nil l selects slog.Default().
+func WithLogger(l *slog.Logger) Option {
+	return func(o *dialOptions) { o.logger = l }
+}
+```
+
+In `ftp.go`:
+- Add field to `FTPSession`:
+```go
+	log *log.Logger
+```
+- In `newSession`, set it (nil cfg.logger ⇒ lazy default):
+```go
+	return &FTPSession{
+		conn:      conn,
+		rawConn:   conn,
+		reader:    bufio.NewReader(conn),
+		dialCfg:   cfg,
+		jobPrefix: regexp.MustCompile(`(JOB\d{5})`),
+		log:       log.New(cfg.logger, log.None),
+	}
+```
+- Replace `SetVerbose` body:
+```go
+func (s *FTPSession) SetVerbose(level LogLevel) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.log.SetLevel(log.Level(level))
+}
+```
+- Add setter:
+```go
+// SetLogger swaps the destination logger for this session's logs at runtime.
+// A nil l reverts to slog.Default().
+func (s *FTPSession) SetLogger(l *slog.Logger) {
+	s.log.SetSlog(l)
+}
+```
+
+> `newSession(nil, …)` is valid: the tests pass a nil conn and never do I/O —
+> `bufio.NewReader(nil)` is fine when unread. Real sessions pass a live conn.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test -race . -run 'TestPerSessionLoggerIsolation|TestWithLoggerOption|TestDefaultSessionSilent' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Full build/vet (call sites still on shims)**
+
+Run: `CGO_ENABLED=0 go build ./... && go test -race ./... 2>&1 | tail -15`
+Expected: success; existing suite green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add options.go ftp.go log.go logger_session_test.go
+git commit -m "feat: per-session slog logger (WithLogger option + SetLogger), SetVerbose now per-session"
+```
+
+---
+
+### Tasks 4–8: Migrate call sites from package shims to the session logger
+
+**Transformation rule:** replace `log.X(...)` with the session's logger. The receiver is `s.log` in `*FTPSession` methods. For non-session sites, thread a `*log.Logger` (see each task). After each file, no `log.<emitter>(` package calls remain in it. The `log` import stays only where the `log.Level`/type is still referenced (none after migration) — goimports will drop unused imports.
+
+**Verification after every task:**
+```bash
+CGO_ENABLED=0 go build ./... && go vet ./... && go test -race ./... 2>&1 | tail -8
+```
+All green (shims still exist for not-yet-migrated files).
+
+---
+
+### Task 4: Migrate ftp.go + cmd.go (pure `*FTPSession` methods)
+
+**Files:** Modify `ftp.go`, `cmd.go`.
+
+- [ ] **Step 1: ftp.go** — these are inside `*FTPSession` methods or `Open` (which holds `session`):
+  - `ftp.go:60` `log.Debug(...)` → `session.log.Debug(...)` (inside `Open`, var is `session`).
+  - `ftp.go:114` `log.Errorf(...)` → `s.log.Errorf(...)` (inside `installSignalHandler`, receiver `s`).
+  - `ftp.go:195` `log.Debugf(...)`, `:197` `log.Warningf(...)`, `:202` `log.Debugf(...)`, `:204` `log.Warningf(...)` → `s.log.…` (Close path; confirm receiver name).
+- [ ] **Step 2: cmd.go** — all inside `*FTPSession` methods (receiver `s`):
+  - `:57` `log.Commandf`, `:64` `log.Serverf`, `:94/:96/:98` `log.Commandf`, `:124` `log.Warningf`, `:144` `log.Serverf` → `s.log.…`.
+- [ ] **Step 3: Confirm zero residual + verify**
+
+Run: `rg -n 'log\.(Debug|Command|Server|Passive|Warning|Error)' ftp.go cmd.go` → no matches.
+Run the verification block. Expected: green.
+- [ ] **Step 4: Commit** `refactor(log): route ftp.go + cmd.go through the session logger`
+
+---
+
+### Task 5: Migrate put.go + get.go + transfer.go (`*FTPSession` methods)
+
+**Files:** Modify `put.go`, `get.go`, `transfer.go`.
+
+- [ ] **Step 1:** `put.go` (14×`Debugf`, 2×`Errorf`, 2×`Error`, 2×`Debug`, 1×`Warning` at the lines from the appendix) → `s.log.…`. Confirm each enclosing method's receiver name (`s`).
+- [ ] **Step 2:** `get.go` (5×`Debug`, 4×`Debugf`) → `s.log.…`.
+- [ ] **Step 3:** `transfer.go:112` `log.Error(err)` → `s.log.Error(err)` (confirm receiver; if the function is not a method, see Task 8 pattern and pass a `*log.Logger`).
+- [ ] **Step 4:** `rg -n 'log\.(Debug|Command|Server|Passive|Warning|Error)' put.go get.go transfer.go` → none. Verify block. Commit `refactor(log): route put/get/transfer through the session logger`.
+
+---
+
+### Task 6: Migrate codes.go (`ReturnCode.check` gains a logger param)
+
+`ReturnCode.check` logs but is not a session method. Thread a `*log.Logger`.
+
+**Files:** Modify `codes.go`, and every `.check(` caller. Test: `codes_test.go`.
+
+- [ ] **Step 1:** Change signature `func (rc ReturnCode) check(r *bufio.Reader) (string, error)` → `func (rc ReturnCode) check(r *bufio.Reader, lg *log.Logger) (string, error)`; inside, `log.Serverf`→`lg.Serverf`, `log.Errorf`→`lg.Errorf`.
+- [ ] **Step 2:** Update callers:
+  - `ftp.go:55` `CodeSvcReadySoon.check(session.reader)` → `…check(session.reader, session.log)`.
+  - cmd.go / wherever `.check(` is called in the send path → pass `s.log`. Find them: `rg -n '\.check\(' --type go | rg -v _test.go`.
+  - `codes_test.go` callers → pass `ilog.New(nil, ilog.None)` (import internal/log as `ilog`) or a capturing logger.
+- [ ] **Step 3:** `rg -n 'log\.(Server|Error)' codes.go` → none. Verify block (incl. `go test -race .`). Commit `refactor(log): thread session logger into ReturnCode.check`.
+
+---
+
+### Task 7: Migrate passive.go (childConnection carries a logger) + lists.go
+
+**Files:** Modify `passive.go`, `lists.go`.
+
+- [ ] **Step 1:** Add an unexported field to `childConnection`: `lg *log.Logger`. Set it where the child is created (the session creating it passes `s.log`). Replace the 6 `log.Debugf` in `passive.go` with `c.lg.Debugf(...)` (confirm receiver name on each method).
+- [ ] **Step 2:** `lists.go`:
+  - `:36`, `:52` `log.Error(err)` → `s.log.Error(err)`; `:69` `log.Passivef` → `s.log.Passivef` (confirm `anyList` has the session; if it takes `s *FTPSession`, use `s.log`).
+  - `:25` `log.Panicf("invalid command: %s", cmd)` → 
+    ```go
+    s.log.Errorf("invalid command: %s", cmd)
+    panic(fmt.Sprintf("invalid command: %s", cmd))
+    ```
+    (add `fmt` import if needed). If no session is in scope at that point, keep a bare `panic(fmt.Sprintf(...))` — it is a programmer-error guard.
+- [ ] **Step 3:** `rg -n 'log\.(Debug|Passive|Error|Panic)' passive.go lists.go` → none. Verify block. Commit `refactor(log): childConnection logger + lists.go (drop log.Panicf)`.
+
+---
+
+### Task 8: Migrate internal/utils (logging helpers take a `*log.Logger`)
+
+**Files:** Modify `internal/utils/utils.go` and its callers.
+
+- [ ] **Step 1:** For each helper that logs (`utils.go:101` `Debugf`, `:188` `Warning`), add a trailing `lg *log.Logger` parameter and replace `log.X`→`lg.X`. (Import `gopkg.in/ro-ag/zftp.v2/internal/log`.)
+- [ ] **Step 2:** Update callers (in the `zftp` package) to pass `s.log`. Find them by the helper names: `rg -n '<helperName>\(' --type go`.
+- [ ] **Step 3:** Audit `internal/transfer`: `rg -n 'internal/log|log\.' internal/transfer`. If any site logs, apply the same `*log.Logger`-param pattern; else no change.
+- [ ] **Step 4:** `rg -rn 'log\.(Debug|Command|Server|Passive|Warning|Error)' internal/utils internal/transfer` → none. Verify block. Commit `refactor(log): thread logger into internal/utils helpers`.
+
+---
+
+### Task 9: Remove transitional shims; confirm clean
+
+**Files:** Modify `internal/log/logger.go`.
+
+- [ ] **Step 1:** Confirm no remaining package-shim users:
+  Run: `rg -n 'log\.(SetLevel|Debug|Debugf|Command|Commandf|Passive|Passivef|Server|Serverf|Warning|Warningf|Error|Errorf)\(' --type go | rg -v 'internal/log/|\.log\.|_test.go'`
+  Expected: no matches. (Anything left is an un-migrated site — migrate it before deleting shims.)
+- [ ] **Step 2:** Delete the shim block (the `var std` + the package funcs) from `internal/log/logger.go`.
+- [ ] **Step 3:** Verify the source-line test still passes (records now never go through a shim):
+  Run: `go test -race ./internal/log/ -run TestLogger_SourcePointsAtCallSite -v` → PASS.
+- [ ] **Step 4:** Full verify block + `go test -race ./...`. Commit `refactor(log): remove transitional package shims`.
+
+---
+
+### Task 10: Documentation — README logger-injection section
+
+**Files:** Modify `README.md` (and any `doc.go`).
+
+- [ ] **Step 1:** Add a "Logging" section documenting: default is silent until `SetVerbose`; `WithLogger(*slog.Logger)` + `SetLogger`; the `component=zftp` + `category` attributes; the level mapping (trace→Debug, Warning→Warn, Error→Error). Include the three bridge snippets from the spec, each marked "verify the bridge constructor against its current release."
+- [ ] **Step 2:** `CGO_ENABLED=0 go build ./...` (docs-only, sanity). Commit `docs: document per-session slog logger injection`.
+
+---
+
+### Task 11: Final gate, PR, project item
+
+- [ ] **Step 1: Full gate (show output)**
+
+```bash
+export PATH="$(go env GOPATH)/bin:$PATH"
+CGO_ENABLED=0 go build ./... && CGO_ENABLED=0 go vet ./... && staticcheck ./... && go test -race ./... && govulncheck ./...
+```
+Expected: all green; `govulncheck` → "No vulnerabilities found."
+
+- [ ] **Step 2: Adversarial review** — `cavecrew-reviewer` over `git diff main...feat/logger-injection` (dispatch with `isolation: worktree` so it does not `git checkout` the shared tree — see workflow-prefs gotcha).
+
+- [ ] **Step 3: Project + PR** — create a Project #3 draft item ("Per-session slog logger injection"), promote draft→issue in place (`convertProjectV2DraftIssueItemToIssue`, `itemId`+`repositoryId` only), set a Priority + Status=In Progress; push; `gh pr create --base main` with `Closes #N`; wait for CI green; merge (`--merge --delete-branch`); confirm board → Done; update project memory.
+
+---
+
+## Self-Review
+
+**Spec coverage:** slog bridge ✓(T2,T3,T10) · per-session ✓(T3) · bitmask prefilter + category attr ✓(T2) · `*slog.Logger`+`slog.Default()` lazy ✓(T2,T3) · drop Fatal/Panic ✓(T7; Fatal only in stdlib-`log` example_test, untouched) · component on every record ✓(T2) · go 1.21 + CI ✓(T1) · call-site threading incl. utils/transfer ✓(T4–T8) · tests (prefilter, mapping, attrs, always-on, default, source, race, isolation) ✓(T2,T3) · breaking-change/migration ✓(T1,T9) · README bridges ✓(T10) · gate ✓(T11).
+
+**Placeholder scan:** the `wantLine` placeholder in the source test is explicitly annotated to be deleted; all other steps carry real code/commands.
+
+**Type consistency:** `New(*slog.Logger, Level) *Logger`; `SetSlog`/`SetLevel`/`Level()`; emitters `Xf(string, ...any)`/`X(...any)`; `WithLogger(*slog.Logger) Option`; `(*FTPSession).SetLogger(*slog.Logger)`; `check(*bufio.Reader, *log.Logger)`; `childConnection.lg`. Used consistently across tasks.

--- a/docs/superpowers/plans/2026-06-22-logger-injection.md
+++ b/docs/superpowers/plans/2026-06-22-logger-injection.md
@@ -6,11 +6,11 @@
 
 **Architecture:** Rewrite `internal/log` from a global singleton into a `Logger` value type that applies the category bitmask prefilter and emits structured `slog` records. Each `*FTPSession` owns one. Transitional package-level shims keep the build green while ~60 call sites migrate file-by-file; the shims are deleted at the end.
 
-**Tech Stack:** Go 1.21+ (`log/slog`), `internal/mockzos` loopback for tests.
+**Tech Stack:** Go 1.26 (`log/slog`; floor set to current Go — see Global Constraints), `internal/mockzos` loopback for tests.
 
 ## Global Constraints
 
-- **Go floor:** `go 1.21` in `go.mod`; CI matrix `["1.21","stable"]`. (slog is stdlib from 1.21.)
+- **Go floor:** `go 1.26` in `go.mod` + `cli/go.mod`; CI matrix `["1.26","stable"]`. (slog needs ≥1.21; floor set to 1.26 to dodge the Go 1.21 macOS `-race` LC_UUID toolchain bug.)
 - **Zero third-party deps in core.** Only stdlib (incl. `log/slog`). zap/zerolog bridge in the user's app.
 - **SPDX header** `// SPDX-License-Identifier: Apache-2.0` on every `.go` file (first line).
 - **Errors:** `errors.New` for static sentinels, `%w` for wraps.

--- a/docs/superpowers/specs/2026-06-22-logger-injection-design.md
+++ b/docs/superpowers/specs/2026-06-22-logger-injection-design.md
@@ -1,0 +1,290 @@
+# Logger Injection — per-session `slog` integration
+
+- **Status:** Approved (brainstorm), pending implementation plan
+- **Date:** 2026-06-22
+- **Branch:** `feat/logger-injection`
+- **Module:** `gopkg.in/ro-ag/zftp.v2`
+- **Tracking:** to be promoted as a draft item in GitHub Project #3 (priority + In Progress on PR)
+
+## Problem
+
+`internal/log` is a **process-global singleton**. The public surface exposes only
+`(*FTPSession).SetVerbose(LogLevel)` (a session method that mutates global state)
+and the `LogLevel` constants. There is **no way to inject a logger**: output is
+hardwired to `os.Stderr` via the stdlib `log.Logger`, and the internal `SetLogger`
+takes a stdlib-`*log.Logger`-shaped interface (`Printf/Print/Panic/Prefix/Writer`)
+that maps poorly onto structured, leveled loggers.
+
+Users want zftp's logs to flow into their application's logging pipeline —
+`log/slog`, `zap`, or `zerolog` — with proper levels and structured fields.
+
+## Goals
+
+- Let callers inject a logger so zftp logs route into their pipeline.
+- Support `slog`, `zap`, and `zerolog` **without adding any third-party dependency
+  to the core module**.
+- Preserve the existing category model (`Server/Passive/Command/Debug` bitmask via
+  `SetVerbose`, the ZH06 fix) and keep `LogLevel` source-compatible.
+- Make logging **per-session**: no global mutable logging state.
+
+## Non-goals
+
+- Re-keying existing call sites into fully structured attribute sets. Existing
+  preformatted messages become the slog *message*; richer attrs are a future,
+  incremental improvement.
+- Native (non-slog) adapter modules for zap/zerolog. They bridge via slog handlers.
+- Changing transfer/protocol behavior. This is a logging-plumbing change only.
+
+## Decisions (locked during brainstorm)
+
+1. **slog is the bridge.** Core depends only on stdlib `log/slog`. zap plugs in via
+   `go.uber.org/zap/exp/zapslog`; zerolog via a zerolog→slog handler (e.g.
+   `samber/slog-zerolog`). Bridging code lives in the *user's* app, not in core.
+2. **Per-session.** Each `*FTPSession` owns its own `*log.Logger` (wrapping a
+   `*slog.Logger` + a category bitmask). No package-global logger state remains.
+3. **Bitmask prefilter + `category` attribute.** `SetVerbose(LogLevel)` stays the
+   "what to trace" prefilter. Enabled categories emit structured slog records:
+   trace categories at `slog.LevelDebug` with a `category` attribute; `Warning`→
+   `slog.LevelWarn`; `Error`→`slog.LevelError`.
+4. **Accept `*slog.Logger`, default to `slog.Default()`.** Inject via a
+   `WithLogger(*slog.Logger)` functional option (matching existing
+   `WithSignalHandler`/`WithReplyTimeout` style) plus a `SetLogger` runtime setter.
+   No injection ⇒ fall back to `slog.Default()`.
+
+### Sub-decisions (confirmed: "All")
+
+- **(a) Lazy default.** When no logger is injected, `slog.Default()` is resolved
+  **at emit time**, not captured at `Open`, so a later `slog.SetDefault(...)` is
+  honored.
+- **(b) Drop `Fatal`/`Panic` from the logger.** slog has no Fatal/Panic. The sole
+  real `log.Panicf` (`lists.go:25`, an invalid-command programmer error) becomes an
+  `Error` log followed by a direct `panic(...)`. `log.Fatal` appears only in
+  `example_test.go` and is removed there.
+- **(c) Stable `component="zftp"` on every record.** The session's base logger is
+  derived once via `injected.With(slog.String("component", "zftp"))`, so **all**
+  zftp records (including warn/error) are greppable; trace lines additionally carry
+  `category`.
+
+## Architecture
+
+`internal/log` is rewritten from a package of globals into a `Logger` **value type**.
+
+```go
+package log // internal/log
+
+type Level uint32 // unchanged ZH06 bits: None=0, Server=1, Passive=2, Command=4, Debug=8, All=15
+
+type Logger struct {
+    base  atomic.Pointer[slog.Logger] // nil ⇒ resolve slog.Default().With(component) lazily
+    level atomic.Uint32               // category bitmask
+}
+
+// New wraps l (nil ⇒ lazy slog.Default()) at the given category level. The
+// returned Logger is safe for concurrent use.
+func New(l *slog.Logger, lvl Level) *Logger
+
+func (l *Logger) SetLevel(lvl Level)
+func (l *Logger) Level() Level
+func (l *Logger) SetSlog(s *slog.Logger) // nil ⇒ revert to lazy default
+func (l *Logger) enabled(cat Level) bool // level.Load()&cat != 0
+```
+
+`*FTPSession` gains an unexported field `log *log.Logger`, set in `Open` (from
+`WithLogger`, else `log.New(nil, NoLog)`). Every current `log.X(...)` call becomes
+`s.log.X(...)`.
+
+### Emission
+
+A single internal helper builds the record with the **caller's** source location
+(so `slog`'s `AddSource` points at the real call site, not the wrapper):
+
+```go
+func (l *Logger) emit(level slog.Level, msg string, attrs ...slog.Attr) {
+    base := l.resolve()                 // injected logger, or slog.Default().With(component=zftp)
+    if !base.Enabled(context.Background(), level) {
+        return
+    }
+    var pcs [1]uintptr
+    runtime.Callers(3, pcs[:])          // skip [Callers, emit, category method] → real call site
+    r := slog.NewRecord(time.Now(), level, msg, pcs[0])
+    r.AddAttrs(attrs...)
+    _ = base.Handler().Handle(context.Background(), r)
+}
+```
+
+> `component=zftp` is applied **once** at injection: `New`/`SetSlog` store
+> `l.With(slog.String("component","zftp"))`. `resolve()` returns that stored base
+> when set; otherwise it returns `slog.Default().With(slog.String("component",
+> "zftp"))` (lazy, per (a)+(c)). Either way every emitted record is tagged, with no
+> per-emit `With` on the injected path.
+
+### Category methods (keep printf-style to minimize call-site churn)
+
+```go
+func (l *Logger) Commandf(format string, a ...any) {
+    if l.enabled(CommandLevel) {
+        l.emit(slog.LevelDebug, fmt.Sprintf(format, a...), slog.String("category", "command"))
+    }
+}
+// Serverf/Passivef/Debugf — same shape, category "server"/"passive"/"debug"
+func (l *Logger) Warningf(format string, a ...any) { l.emit(slog.LevelWarn, fmt.Sprintf(format, a...)) }
+func (l *Logger) Errorf(format string, a ...any)   { l.emit(slog.LevelError, fmt.Sprintf(format, a...)) }
+// Non-f variants (Debug/Error/Warning/...) wrap fmt.Sprint(a...) — current call sites use both.
+```
+
+### Level mapping
+
+| zftp call | gated by | slog level | attrs |
+|---|---|---|---|
+| `Commandf`/`Command` | `CommandLevel` bit | `LevelDebug` | `component=zftp`, `category=command` |
+| `Serverf`/`Server` | `ServerLevel` bit | `LevelDebug` | `component=zftp`, `category=server` |
+| `Passivef`/`Passive` | `PassiveLevel` bit | `LevelDebug` | `component=zftp`, `category=passive` |
+| `Debugf`/`Debug` | `DebugLevel` bit | `LevelDebug` | `component=zftp`, `category=debug` |
+| `Warningf`/`Warning` | always | `LevelWarn` | `component=zftp` |
+| `Errorf`/`Error` | always | `LevelError` | `component=zftp` |
+
+Two filters compose: zftp's bitmask decides whether a line is emitted at all; the
+slog handler's own level/handler decides whether it is recorded/printed.
+
+## Call-site threading
+
+~60 sites across 9 files (see appendix). Threading rules:
+
+- **`*FTPSession` methods** (cmd.go, put.go, get.go, ftp.go, most of lists.go):
+  `log.X` → `s.log.X`. Mechanical.
+- **Types that log without a session:**
+  - `childConnection` (passive.go) carries an unexported `lg *log.Logger`, set by
+    the session when the child is created. Its methods log via `c.lg.X`.
+  - `ReturnCode.check` (codes.go) gains a `*log.Logger` parameter, supplied by the
+    session command path that invokes it.
+- **Free helpers in `internal/utils`** (`utils.go:101`, `:188`) take a
+  `*log.Logger` parameter from their session callers.
+- **`internal/transfer`**: audit during implementation; if any site logs, it
+  receives a `*log.Logger` parameter. (Current grep shows none.)
+- **`lists.go:25` `log.Panicf`** → `s.log.Errorf(...)` then `panic(fmt.Sprintf(...))`.
+
+Exact signatures are finalized in the implementation plan; the mechanism (pass the
+session's `*log.Logger`, or store a reference on the logging type at construction)
+is fixed here.
+
+## Public API (zftp package)
+
+```go
+// WithLogger routes this session's logs into l. A nil l selects slog.Default().
+func WithLogger(l *slog.Logger) Option
+
+// SetLogger swaps the session's logger at runtime. A nil l reverts to slog.Default().
+func (s *FTPSession) SetLogger(l *slog.Logger)
+
+// SetVerbose selects which trace categories this session emits (unchanged signature).
+func (s *FTPSession) SetVerbose(level LogLevel)
+
+// LogLevel + NoLog/LogServer/LogPassive/LogCommand/LogDebug/LogAll — unchanged.
+```
+
+Default session (`Open` with no `WithLogger`, no `SetVerbose`): logger resolves to
+`slog.Default()`, level `NoLog` ⇒ **silent until `SetVerbose`** (preserves today's
+default-quiet behavior).
+
+### Bridging examples (documentation)
+
+```go
+// slog (stdlib) — direct
+h := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug})
+s, _ := zftp.Open(addr, zftp.WithLogger(slog.New(h)))
+s.SetVerbose(zftp.LogCommand | zftp.LogServer)
+
+// zap — via a zap→slog handler (go.uber.org/zap/exp/zapslog)
+s, _ := zftp.Open(addr, zftp.WithLogger(slog.New(zapHandler)))   // zapHandler is a slog.Handler
+
+// zerolog — via a zerolog→slog handler (e.g. samber/slog-zerolog)
+s, _ := zftp.Open(addr, zftp.WithLogger(slog.New(zerologHandler))) // zerologHandler is a slog.Handler
+```
+
+*Exact handler constructors are taken from each bridge's own docs (verify against
+the current release before pasting into the README).* The bridge imports live in the
+**user's** go.mod; core stays zero-dep — all zftp needs is any `slog.Handler`.
+
+## Error handling / concurrency
+
+- A `nil` logger is always valid input (⇒ lazy `slog.Default()`); no nil panics.
+- `level` is an `atomic.Uint32`; the base `*slog.Logger` is an
+  `atomic.Pointer[slog.Logger]`. Reads are lock-free; concurrent `SetLogger` /
+  `SetVerbose` / emit are race-free. Verified under `-race`.
+- Handler errors from `Handle` are ignored (slog convention; nothing actionable).
+
+## Testing (TDD, RED→GREEN, `-race`)
+
+A reusable **capturing `slog.Handler`** (records `[]slog.Record` + attrs) backs the
+assertions.
+
+**internal/log (white-box, extend `logger_test.go`):**
+
+- Prefilter: with level `CommandLevel`, `Commandf` emits exactly one record; the
+  other three trace categories emit zero.
+- Level mapping: trace categories ⇒ `LevelDebug`; `Warningf`⇒`LevelWarn`;
+  `Errorf`⇒`LevelError`.
+- Attrs: every record carries `component=zftp`; trace records carry the right
+  `category`.
+- Always-on: `Warningf`/`Errorf` emit even at level `None`.
+- Default resolution: `New(nil, …)` and `SetSlog(nil)` route to `slog.Default()`
+  (swap the default with a capturing handler via `slog.SetDefault`, restore in
+  `t.Cleanup`); lazy — a `SetDefault` after construction is honored.
+- Source: emitted record `PC` resolves to the test's call site (not the wrapper).
+- Concurrency: goroutines hammering `SetSlog`/`SetLevel`/`Commandf` under `-race`.
+- ZH06 invariants preserved (distinct bits, isolation) — keep existing cases.
+
+**zftp (black-box via `internal/mockzos`):**
+
+- `WithLogger` wires the session: run a mock command flow, assert the injected
+  handler captured `category=command`/`server` records.
+- **Per-session isolation (the core win):** two sessions with different injected
+  handlers and different `SetVerbose` levels — each captures only its own records;
+  no cross-talk.
+- Back-compat: a default session (no `WithLogger`, no `SetVerbose`) captures zero
+  records.
+
+## Breaking changes & migration (pre-ship, approved)
+
+- `go.mod`: `go 1.20` → **`go 1.21`** (slog is stdlib from 1.21).
+- CI matrix `.github/workflows`: `["1.20","stable"]` → `["1.21","stable"]`.
+- Removed (internal only): package-global log funcs, the stdlib-shaped `Logger`
+  interface, `internal/log.SetLogger/SetOutput/SetLevel` globals.
+- Public: `SetVerbose`/`LogLevel` source-compatible; **new** `WithLogger` +
+  `SetLogger`. Log *output format* changes (now slog records).
+- v2 is unreleased ⇒ breaking changes are approved.
+
+## File-by-file change list
+
+- `internal/log/logger.go` — rewrite to `Logger` struct + slog emission.
+- `internal/log/logger_test.go` — extend (capturing handler, mapping, default, race).
+- `log.go` — keep `LogLevel`; (option may live here or in the options file).
+- `ftp.go` — `*FTPSession.log` field; `Open` wiring; `WithLogger`; `SetLogger`;
+  `SetVerbose` → `s.log.SetLevel`.
+- `cmd.go`, `codes.go`, `passive.go`, `put.go`, `get.go`, `lists.go`, `transfer.go`
+  — `log.X` → session/childConn/param logger; `Panicf`→`Error`+`panic`.
+- `internal/utils/utils.go`, `internal/transfer/*` — logging helpers take
+  `*log.Logger`.
+- `go.mod`, `.github/workflows/*.yml` — version bump.
+- `README` / examples — logger injection + zap/zerolog bridge snippets.
+
+## Risks / open questions
+
+- **Source line (`AddSource`)**: the `runtime.Callers` skip depth must be verified
+  empirically (Sprintf vs non-f paths may differ); a test pins it.
+- **`internal/transfer` logging**: confirm there are truly no sites; adjust the
+  threading list if the audit finds any.
+- **Default `component` cost**: deriving `slog.Default().With(...)` lazily per emit
+  allocates; if it shows up in profiles, cache the derived default and invalidate on
+  `slog.SetDefault` (acceptable to defer — tracing is opt-in/off by default).
+
+## Acceptance criteria
+
+- Injecting a `*slog.Logger` routes zftp logs into it; zap/zerolog work via their
+  slog handlers with **zero** new core dependencies.
+- Logging is per-session: two sessions log independently (no global state); proven
+  by an isolation test.
+- `SetVerbose`/`LogLevel` unchanged for callers; ZH06 bit invariants intact.
+- `CGO_ENABLED=0 go build ./...`, `go vet ./...`, `staticcheck ./...`,
+  `go test -race ./...`, `govulncheck ./...` all green; CI green on `go 1.21` +
+  `stable`.

--- a/docs/superpowers/specs/2026-06-22-logger-injection-design.md
+++ b/docs/superpowers/specs/2026-06-22-logger-injection-design.md
@@ -246,8 +246,11 @@ assertions.
 
 ## Breaking changes & migration (pre-ship, approved)
 
-- `go.mod`: `go 1.20` → **`go 1.21`** (slog is stdlib from 1.21).
-- CI matrix `.github/workflows`: `["1.20","stable"]` → `["1.21","stable"]`.
+- `go.mod` (and `cli/go.mod`): `go 1.20` → **`go 1.26`**. slog needs ≥1.21, but
+  Go 1.21's macOS `-race`/CGO binaries hit a dyld "missing LC_UUID" loader bug
+  (fixed in 1.22+); the maintainer chose to set the floor to the current Go (1.26)
+  so the full race matrix is green with no per-leg exclusions.
+- CI matrix `.github/workflows`: `["1.20","stable"]` → `["1.26","stable"]`.
 - Removed (internal only): package-global log funcs, the stdlib-shaped `Logger`
   interface, `internal/log.SetLogger/SetOutput/SetLevel` globals.
 - Public: `SetVerbose`/`LogLevel` source-compatible; **new** `WithLogger` +
@@ -286,5 +289,5 @@ assertions.
   by an isolation test.
 - `SetVerbose`/`LogLevel` unchanged for callers; ZH06 bit invariants intact.
 - `CGO_ENABLED=0 go build ./...`, `go vet ./...`, `staticcheck ./...`,
-  `go test -race ./...`, `govulncheck ./...` all green; CI green on `go 1.21` +
+  `go test -race ./...`, `govulncheck ./...` all green; CI green on `go 1.26` +
   `stable`.

--- a/ftp.go
+++ b/ftp.go
@@ -54,7 +54,7 @@ func Open(server string, opts ...Option) (*FTPSession, error) {
 
 	session := newSession(conn, cfg)
 
-	msg, err := CodeSvcReadySoon.check(session.reader)
+	msg, err := CodeSvcReadySoon.check(session.reader, session.log)
 	if err != nil {
 		_ = conn.Close()
 		return nil, err

--- a/ftp.go
+++ b/ftp.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/ro-ag/zftp.v2/eol"
 	"gopkg.in/ro-ag/zftp.v2/internal/log"
 	"gopkg.in/ro-ag/zftp.v2/internal/utils"
+	"log/slog"
 	"net"
 	"os"
 	"os/signal"
@@ -35,6 +36,7 @@ type FTPSession struct {
 	dataConns   sync.Map
 	tlsConfig   *tls.Config
 	dialCfg     dialOptions
+	log         *log.Logger
 	mu          sync.Mutex
 }
 
@@ -100,6 +102,7 @@ func newSession(conn net.Conn, cfg dialOptions) *FTPSession {
 		reader:    bufio.NewReader(conn),
 		dialCfg:   cfg,
 		jobPrefix: regexp.MustCompile(`(JOB\d{5})`),
+		log:       log.New(cfg.logger, log.None),
 	}
 }
 
@@ -118,11 +121,19 @@ func (s *FTPSession) installSignalHandler() {
 	}()
 }
 
-// SetVerbose sets the verbose flag
+// SetVerbose selects which trace categories this session emits. The level is a
+// bitmask of the Log* constants (or NoLog/LogAll) and is independent of any
+// injected logger's own level filter.
 func (s *FTPSession) SetVerbose(level LogLevel) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	log.SetLevel(log.Level(level))
+	s.log.SetLevel(log.Level(level))
+}
+
+// SetLogger swaps the destination logger for this session's logs at runtime.
+// A nil l reverts to slog.Default(). See WithLogger to set it at Open time.
+func (s *FTPSession) SetLogger(l *slog.Logger) {
+	s.log.SetSlog(l)
 }
 
 // Conn exposes the underlying network connection used by the session.

--- a/ftp.go
+++ b/ftp.go
@@ -59,7 +59,7 @@ func Open(server string, opts ...Option) (*FTPSession, error) {
 		_ = conn.Close()
 		return nil, err
 	}
-	log.Debug(utils.WrapText(msg))
+	session.log.Debug(utils.WrapText(msg))
 
 	if cfg.signalHandler {
 		session.installSignalHandler()
@@ -114,7 +114,7 @@ func (s *FTPSession) installSignalHandler() {
 	go func() {
 		<-c
 		if err := s.Close(); err != nil {
-			log.Errorf("error closing FTP session: %s", err)
+			s.log.Errorf("error closing FTP session: %s", err)
 			os.Exit(1)
 		}
 		os.Exit(0)
@@ -203,16 +203,16 @@ func (s *FTPSession) closeLocked() error {
 	// Close all data connections.
 	s.dataConns.Range(func(name, conn any) bool {
 		child := conn.(*childConnection)
-		log.Debugf("closing child net connection %s", child.RemoteAddr())
+		s.log.Debugf("closing child net connection %s", child.RemoteAddr())
 		if err := child.Close(); err != nil {
-			log.Warningf("Error closing child net connection %s: %s", child.RemoteAddr(), err)
+			s.log.Warningf("Error closing child net connection %s: %s", child.RemoteAddr(), err)
 		}
 		return true
 	})
 
-	log.Debugf("closing session connection %s", s.conn.RemoteAddr())
+	s.log.Debugf("closing session connection %s", s.conn.RemoteAddr())
 	if err := s.conn.Close(); err != nil {
-		log.Warningf("Error closing session connection: %s", err)
+		s.log.Warningf("Error closing session connection: %s", err)
 		return err
 	}
 	return nil

--- a/get.go
+++ b/get.go
@@ -134,7 +134,7 @@ func (s *FTPSession) GetAndGzip(remote string, localFile string, mode TransferTy
 
 	s.log.Debugf("successfully transferred and compressed %d bytes from %s", bytesTransferred, remote)
 
-	err = utils.VerifyGzSize(file, bytesTransferred)
+	err = utils.VerifyGzSize(s.log, file, bytesTransferred)
 	if err != nil {
 		return err
 	}

--- a/get.go
+++ b/get.go
@@ -5,7 +5,6 @@ package zftp
 import (
 	"compress/gzip"
 	"fmt"
-	"gopkg.in/ro-ag/zftp.v2/internal/log"
 	"gopkg.in/ro-ag/zftp.v2/internal/utils"
 	"io"
 	"os"
@@ -16,7 +15,7 @@ import (
 // If the local file already exists, it is overwritten.
 // mode is the transfer mode, either ASCII or binary.
 func (s *FTPSession) Get(remote string, localFile string, mode TransferType) error {
-	log.Debug("creating local file: ", localFile)
+	s.log.Debug("creating local file: ", localFile)
 	file, err := os.Create(localFile)
 	if err != nil {
 		return fmt.Errorf("failed to create local file: %w", err)
@@ -33,13 +32,13 @@ func (s *FTPSession) Get(remote string, localFile string, mode TransferType) err
 		}
 	}()
 
-	log.Debug("starting transfer from: ", remote)
+	s.log.Debug("starting transfer from: ", remote)
 	bytesTransferred, _, err := s.RetrieveIO(remote, file, mode)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve file: %w", err)
 	}
 
-	log.Debugf("Successfully transferred %d bytes from %s", bytesTransferred, remote)
+	s.log.Debugf("Successfully transferred %d bytes from %s", bytesTransferred, remote)
 	return nil
 }
 
@@ -55,7 +54,7 @@ func (s *FTPSession) GetAt(remote string, localFile string, mode TransferType, o
 		return err
 	}
 
-	log.Debug("opening local file: ", localFile)
+	s.log.Debug("opening local file: ", localFile)
 
 	file, err := os.OpenFile(localFile, os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
@@ -85,13 +84,13 @@ func (s *FTPSession) GetAt(remote string, localFile string, mode TransferType, o
 		}
 	}()
 
-	log.Debugf("starting transfer from %s at offset %d", remote, offset)
+	s.log.Debugf("starting transfer from %s at offset %d", remote, offset)
 	bytesTransferred, _, err := s.RetrieveIOAt(remote, file, mode, offset)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve file: %w", err)
 	}
 
-	log.Debugf("successfully transferred %d bytes from %s", bytesTransferred, remote)
+	s.log.Debugf("successfully transferred %d bytes from %s", bytesTransferred, remote)
 	return nil
 }
 
@@ -105,7 +104,7 @@ func (s *FTPSession) GetAndGzip(remote string, localFile string, mode TransferTy
 		localFile += ".gz"
 	}
 
-	log.Debug("creating local file: ", localFile)
+	s.log.Debug("creating local file: ", localFile)
 	file, err := os.Create(localFile)
 	if err != nil {
 		return fmt.Errorf("failed to create local file: %w", err)
@@ -117,7 +116,7 @@ func (s *FTPSession) GetAndGzip(remote string, localFile string, mode TransferTy
 		err = closeGzHandler(err, gzWriter, file)
 	}()
 
-	log.Debug("starting transfer from: ", remote)
+	s.log.Debug("starting transfer from: ", remote)
 	bytesTransferred, _, err := s.RetrieveIO(remote, gzWriter, mode)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve and compress file: %w", err)
@@ -133,7 +132,7 @@ func (s *FTPSession) GetAndGzip(remote string, localFile string, mode TransferTy
 		return fmt.Errorf("failed to close gzip writer: %w", err)
 	}
 
-	log.Debugf("successfully transferred and compressed %d bytes from %s", bytesTransferred, remote)
+	s.log.Debugf("successfully transferred and compressed %d bytes from %s", bytesTransferred, remote)
 
 	err = utils.VerifyGzSize(file, bytesTransferred)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module gopkg.in/ro-ag/zftp.v2
 
-go 1.20
+go 1.21

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module gopkg.in/ro-ag/zftp.v2
 
-go 1.21
+go 1.26

--- a/internal/log/logger.go
+++ b/internal/log/logger.go
@@ -152,31 +152,3 @@ func (l *Logger) Warning(v ...any)            { l.emit(slog.LevelWarn, fmt.Sprin
 func (l *Logger) Warningf(f string, v ...any) { l.emit(slog.LevelWarn, fmt.Sprintf(f, v...)) }
 func (l *Logger) Error(v ...any)              { l.emit(slog.LevelError, fmt.Sprint(v...)) }
 func (l *Logger) Errorf(f string, v ...any)   { l.emit(slog.LevelError, fmt.Sprintf(f, v...)) }
-
-// --- transitional package-level shims (removed once every call site uses a
-// *Logger; see the migration plan). They delegate to a package default so existing
-// call sites compile unchanged during the migration. ---
-
-var std = New(nil, None)
-
-func SetLevel(lvl Level)          { std.SetLevel(lvl) }
-func Debug(v ...any)              { std.Debug(v...) }
-func Debugf(f string, v ...any)   { std.Debugf(f, v...) }
-func Command(v ...any)            { std.Command(v...) }
-func Commandf(f string, v ...any) { std.Commandf(f, v...) }
-func Passive(v ...any)            { std.Passive(v...) }
-func Passivef(f string, v ...any) { std.Passivef(f, v...) }
-func Server(v ...any)             { std.Server(v...) }
-func Serverf(f string, v ...any)  { std.Serverf(f, v...) }
-func Warning(v ...any)            { std.Warning(v...) }
-func Warningf(f string, v ...any) { std.Warningf(f, v...) }
-func Error(v ...any)              { std.Error(v...) }
-func Errorf(f string, v ...any)   { std.Errorf(f, v...) }
-
-// Panicf is a transitional shim for the single lists.go programmer-error guard;
-// it logs at Error then panics. The call site is rewritten to Error+panic during
-// migration, and this shim is removed with the others.
-func Panicf(f string, v ...any) {
-	std.Errorf(f, v...)
-	panic(fmt.Sprintf(f, v...))
-}

--- a/internal/log/logger.go
+++ b/internal/log/logger.go
@@ -3,37 +3,22 @@
 package log
 
 import (
-	"io"
-	"log"
-	"os"
-	"sync"
+	"context"
+	"fmt"
+	"log/slog"
+	"runtime"
 	"sync/atomic"
+	"time"
 )
 
-type Logger interface {
-	SetOutput(w io.Writer)
-	Printf(format string, v ...any)
-	Print(v ...any)
-	Println(v ...any)
-	Fatal(v ...any)
-	Fatalf(format string, v ...any)
-	Fatalln(v ...any)
-	Panic(v ...any)
-	Panicf(format string, v ...any)
-	Panicln(v ...any)
-	Prefix() string
-	SetPrefix(prefix string)
-	Writer() io.Writer
-}
-
+// Level is a bitmask of independent logging categories; combine with OR and test
+// membership with the category emitters. Each flag is a distinct bit, so enabling
+// one category never implies another.
 type Level uint32
 
 // None disables every logging category.
 const None Level = 0
 
-// The four logging categories are independent, single-bit flags: combine them
-// with OR and test membership with IsEnabled. Each occupies a distinct bit, so
-// enabling one category never implies another.
 const (
 	ServerLevel  Level = 1 << iota // 1 — server replies
 	PassiveLevel                   // 2 — passive-mode negotiation
@@ -44,128 +29,154 @@ const (
 // All enables every logging category.
 const All = ServerLevel | PassiveLevel | CommandLevel | DebugLevel
 
-type logger struct {
-	level atomic.Uint32
-	mu    sync.Mutex
-	Logger
+// component tags every zftp record so it is greppable in a shared log stream.
+const component = "zftp"
+
+var (
+	catCommand = slog.String("category", "command")
+	catServer  = slog.String("category", "server")
+	catPassive = slog.String("category", "passive")
+	catDebug   = slog.String("category", "debug")
+)
+
+// Logger applies the category bitmask prefilter and emits structured slog records.
+// The zero value is not usable; construct with New. Safe for concurrent use.
+type Logger struct {
+	base  atomic.Pointer[slog.Logger] // nil ⇒ resolve slog.Default() lazily at emit
+	level atomic.Uint32               // category bitmask
 }
 
-var std = newLogger(log.New(os.Stderr, "", log.LstdFlags), None)
+// New returns a Logger emitting to l at the given category level. A nil l selects
+// slog.Default() at emit time (honoring a later slog.SetDefault).
+func New(l *slog.Logger, lvl Level) *Logger {
+	lg := &Logger{}
+	lg.SetSlog(l)
+	lg.SetLevel(lvl)
+	return lg
+}
 
-func newLogger(l Logger, level Level) *logger {
-	lgr := &logger{
-		Logger: l,
+// SetSlog swaps the destination logger. A nil s reverts to the lazy slog.Default().
+func (l *Logger) SetSlog(s *slog.Logger) {
+	if s == nil {
+		l.base.Store(nil)
+		return
 	}
-	lgr.SetLevel(level)
-	return lgr
+	l.base.Store(tagged(s))
 }
 
-func SetLogger(l Logger) {
-	std.mu.Lock()
-	defer std.mu.Unlock()
-	std.Logger = l
+// SetLevel replaces the category bitmask.
+func (l *Logger) SetLevel(lvl Level) { l.level.Store(uint32(lvl)) }
+
+// Level returns the current category bitmask.
+func (l *Logger) Level() Level { return Level(l.level.Load()) }
+
+func (l *Logger) enabled(cat Level) bool { return l.level.Load()&uint32(cat) != 0 }
+
+// tagged derives a logger carrying the stable component attribute (applied once).
+func tagged(s *slog.Logger) *slog.Logger {
+	return s.With(slog.String("component", component))
 }
 
-func SetOutput(w io.Writer) {
-	std.SetOutput(w)
-}
-
-func SetLevel(level Level) {
-	std.SetLevel(level)
-}
-
-func IsEnabled(level Level) bool {
-	return std.level.Load()&uint32(level) != 0
-}
-
-func (l *logger) SetLevel(level Level) {
-	l.level.Store(uint32(level))
-}
-
-func (l *logger) print(prefix string, v ...any) {
-	l.Print(append([]any{prefix}, v...)...)
-}
-
-func (l *logger) printf(prefix string, format string, v ...interface{}) {
-	l.Printf(prefix+format, v...)
-}
-
-func Debug(v ...any) {
-	if IsEnabled(DebugLevel) {
-		std.print("[***] ", v...)
+// resolve returns the destination logger, tagging the lazy default when no logger
+// was injected.
+func (l *Logger) resolve() *slog.Logger {
+	if b := l.base.Load(); b != nil {
+		return b
 	}
+	return tagged(slog.Default())
 }
 
-func Debugf(format string, v ...any) {
-	if IsEnabled(DebugLevel) {
-		std.printf("[***] ", format, v...)
+// emit builds a record with the caller's source location and dispatches it.
+func (l *Logger) emit(level slog.Level, msg string, attrs ...slog.Attr) {
+	base := l.resolve()
+	ctx := context.Background()
+	if !base.Enabled(ctx, level) {
+		return
 	}
+	var pcs [1]uintptr
+	runtime.Callers(3, pcs[:]) // skip [Callers, emit, category method] → real call site
+	r := slog.NewRecord(time.Now(), level, msg, pcs[0])
+	r.AddAttrs(attrs...)
+	_ = base.Handler().Handle(ctx, r)
 }
 
-func Command(v ...any) {
-	if IsEnabled(CommandLevel) {
-		std.print("[cmd] ", v...)
-	}
-}
-
-func Commandf(format string, v ...any) {
-	if IsEnabled(CommandLevel) {
-		std.printf("[cmd] ", format, v...)
-	}
-}
-
-func Passive(v ...any) {
-	if IsEnabled(PassiveLevel) {
-		std.print("[psv] ", v...)
-	}
-}
-
-func Passivef(format string, v ...any) {
-	if IsEnabled(PassiveLevel) {
-		std.printf("[psv] ", format, v...)
+func (l *Logger) Command(v ...any) {
+	if l.enabled(CommandLevel) {
+		l.emit(slog.LevelDebug, fmt.Sprint(v...), catCommand)
 	}
 }
 
-func Server(v ...any) {
-	if IsEnabled(ServerLevel) {
-		std.print("[res] ", v...)
+func (l *Logger) Commandf(format string, v ...any) {
+	if l.enabled(CommandLevel) {
+		l.emit(slog.LevelDebug, fmt.Sprintf(format, v...), catCommand)
 	}
 }
 
-func Serverf(format string, v ...any) {
-	if IsEnabled(ServerLevel) {
-		std.printf("[res] ", format, v...)
+func (l *Logger) Server(v ...any) {
+	if l.enabled(ServerLevel) {
+		l.emit(slog.LevelDebug, fmt.Sprint(v...), catServer)
 	}
 }
 
-func Error(v ...any) {
-	std.print("[ERRO] ", v...)
+func (l *Logger) Serverf(format string, v ...any) {
+	if l.enabled(ServerLevel) {
+		l.emit(slog.LevelDebug, fmt.Sprintf(format, v...), catServer)
+	}
 }
 
-func Errorf(format string, v ...any) {
-	std.printf("[ERRO]", format, v...)
+func (l *Logger) Passive(v ...any) {
+	if l.enabled(PassiveLevel) {
+		l.emit(slog.LevelDebug, fmt.Sprint(v...), catPassive)
+	}
 }
 
-func Warning(v ...any) {
-	std.print("[WARN] ", v...)
+func (l *Logger) Passivef(format string, v ...any) {
+	if l.enabled(PassiveLevel) {
+		l.emit(slog.LevelDebug, fmt.Sprintf(format, v...), catPassive)
+	}
 }
 
-func Warningf(format string, v ...any) {
-	std.printf("[WARN]", format, v...)
+func (l *Logger) Debug(v ...any) {
+	if l.enabled(DebugLevel) {
+		l.emit(slog.LevelDebug, fmt.Sprint(v...), catDebug)
+	}
 }
 
-func Fatal(v ...any) {
-	std.Fatal(v...)
+func (l *Logger) Debugf(format string, v ...any) {
+	if l.enabled(DebugLevel) {
+		l.emit(slog.LevelDebug, fmt.Sprintf(format, v...), catDebug)
+	}
 }
 
-func Fatalf(format string, v ...any) {
-	std.Fatalf(format, v...)
-}
+func (l *Logger) Warning(v ...any)            { l.emit(slog.LevelWarn, fmt.Sprint(v...)) }
+func (l *Logger) Warningf(f string, v ...any) { l.emit(slog.LevelWarn, fmt.Sprintf(f, v...)) }
+func (l *Logger) Error(v ...any)              { l.emit(slog.LevelError, fmt.Sprint(v...)) }
+func (l *Logger) Errorf(f string, v ...any)   { l.emit(slog.LevelError, fmt.Sprintf(f, v...)) }
 
-func Panic(v ...any) {
-	std.Panic(v...)
-}
+// --- transitional package-level shims (removed once every call site uses a
+// *Logger; see the migration plan). They delegate to a package default so existing
+// call sites compile unchanged during the migration. ---
 
-func Panicf(format string, v ...any) {
-	std.Panicf(format, v...)
+var std = New(nil, None)
+
+func SetLevel(lvl Level)          { std.SetLevel(lvl) }
+func Debug(v ...any)              { std.Debug(v...) }
+func Debugf(f string, v ...any)   { std.Debugf(f, v...) }
+func Command(v ...any)            { std.Command(v...) }
+func Commandf(f string, v ...any) { std.Commandf(f, v...) }
+func Passive(v ...any)            { std.Passive(v...) }
+func Passivef(f string, v ...any) { std.Passivef(f, v...) }
+func Server(v ...any)             { std.Server(v...) }
+func Serverf(f string, v ...any)  { std.Serverf(f, v...) }
+func Warning(v ...any)            { std.Warning(v...) }
+func Warningf(f string, v ...any) { std.Warningf(f, v...) }
+func Error(v ...any)              { std.Error(v...) }
+func Errorf(f string, v ...any)   { std.Errorf(f, v...) }
+
+// Panicf is a transitional shim for the single lists.go programmer-error guard;
+// it logs at Error then panics. The call site is rewritten to Error+panic during
+// migration, and this shim is removed with the others.
+func Panicf(f string, v ...any) {
+	std.Errorf(f, v...)
+	panic(fmt.Sprintf(f, v...))
 }

--- a/internal/log/logger_test.go
+++ b/internal/log/logger_test.go
@@ -3,7 +3,12 @@
 package log
 
 import (
+	"context"
+	"log/slog"
 	"math/bits"
+	"runtime"
+	"strings"
+	"sync"
 	"testing"
 )
 
@@ -11,20 +16,59 @@ import (
 // from these, so the tests assert their relationship rather than listing them.
 var flags = []Level{ServerLevel, PassiveLevel, CommandLevel, DebugLevel}
 
-// restoreLevel snapshots the package singleton's level and restores it when the
-// test finishes. The logger is a process-wide singleton, so without this the
-// cases below would leak state into one another (and into the rest of the
-// package's tests).
-func restoreLevel(t *testing.T) {
-	t.Helper()
-	saved := Level(std.level.Load())
-	t.Cleanup(func() { std.level.Store(uint32(saved)) })
+// capCore is the shared record store behind a capture handler and any
+// WithAttrs-derived children.
+type capCore struct {
+	mu      sync.Mutex
+	records []slog.Record
 }
 
-// TestLevelsAreDistinctSingleBits is the core ZH06 guard: each category must own
-// a single, distinct bit. The original `iota << 1` block produced 2/4/6/8, so
-// CommandLevel(6) == ServerLevel(2)|PassiveLevel(4) and the bitmask checks in
-// IsEnabled bled across categories.
+// capture is a slog.Handler that records every record it handles, honoring
+// attributes accumulated through WithAttrs (e.g. the component tag added by
+// Logger via slog.Logger.With). A faithful handler is required to observe those.
+type capture struct {
+	core  *capCore
+	attrs []slog.Attr
+}
+
+func newCapture() *capture { return &capture{core: &capCore{}} }
+
+func (c *capture) Enabled(context.Context, slog.Level) bool { return true }
+
+func (c *capture) Handle(_ context.Context, r slog.Record) error {
+	rec := r.Clone()
+	rec.AddAttrs(c.attrs...)
+	c.core.mu.Lock()
+	defer c.core.mu.Unlock()
+	c.core.records = append(c.core.records, rec)
+	return nil
+}
+
+func (c *capture) WithAttrs(as []slog.Attr) slog.Handler {
+	merged := append(append([]slog.Attr(nil), c.attrs...), as...)
+	return &capture{core: c.core, attrs: merged}
+}
+
+func (c *capture) WithGroup(string) slog.Handler { return c }
+
+func (c *capture) snapshot() []slog.Record {
+	c.core.mu.Lock()
+	defer c.core.mu.Unlock()
+	return append([]slog.Record(nil), c.core.records...)
+}
+
+// attrMap flattens a record's attributes into a map for assertions.
+func attrMap(r slog.Record) map[string]string {
+	m := map[string]string{}
+	r.Attrs(func(a slog.Attr) bool {
+		m[a.Key] = a.Value.String()
+		return true
+	})
+	return m
+}
+
+// --- ZH06 invariants: the four categories are distinct single bits ---
+
 func TestLevelsAreDistinctSingleBits(t *testing.T) {
 	for _, l := range flags {
 		if got := bits.OnesCount32(uint32(l)); got != 1 {
@@ -59,54 +103,143 @@ func TestAllIsUnionOfTheFourLevels(t *testing.T) {
 	}
 }
 
-// TestSetCommandEnablesOnlyCommand pins the user-visible symptom: selecting one
-// category must not silently switch on its neighbours.
-func TestSetCommandEnablesOnlyCommand(t *testing.T) {
-	restoreLevel(t)
-	SetLevel(CommandLevel)
+// --- ZH06 behavioral invariants, expressed against the Logger bitmask ---
 
-	if !IsEnabled(CommandLevel) {
-		t.Error("CommandLevel must be enabled after SetLevel(CommandLevel)")
+func TestEnabledCommandDoesNotEnableOthers(t *testing.T) {
+	lg := New(nil, CommandLevel)
+	if !lg.enabled(CommandLevel) {
+		t.Error("CommandLevel must be enabled")
 	}
 	for _, l := range []Level{ServerLevel, PassiveLevel, DebugLevel} {
-		if IsEnabled(l) {
-			t.Errorf("level %d must NOT be enabled by SetLevel(CommandLevel)", l)
+		if lg.enabled(l) {
+			t.Errorf("level %d must NOT be enabled by CommandLevel", l)
 		}
 	}
 }
 
-func TestSetDebugEnablesOnlyDebug(t *testing.T) {
-	restoreLevel(t)
-	SetLevel(DebugLevel)
-
-	if !IsEnabled(DebugLevel) {
-		t.Error("DebugLevel must be enabled after SetLevel(DebugLevel)")
+func TestEnabledDebugDoesNotEnableOthers(t *testing.T) {
+	lg := New(nil, DebugLevel)
+	if !lg.enabled(DebugLevel) {
+		t.Error("DebugLevel must be enabled")
 	}
 	for _, l := range []Level{ServerLevel, PassiveLevel, CommandLevel} {
-		if IsEnabled(l) {
-			t.Errorf("level %d must NOT be enabled by SetLevel(DebugLevel)", l)
+		if lg.enabled(l) {
+			t.Errorf("level %d must NOT be enabled by DebugLevel", l)
 		}
 	}
 }
 
-func TestSetAllEnablesEveryLevel(t *testing.T) {
-	restoreLevel(t)
-	SetLevel(All)
-
+func TestEnabledAllEnablesEveryLevel(t *testing.T) {
+	lg := New(nil, All)
 	for _, l := range flags {
-		if !IsEnabled(l) {
-			t.Errorf("level %d must be enabled after SetLevel(All)", l)
+		if !lg.enabled(l) {
+			t.Errorf("level %d must be enabled by All", l)
 		}
 	}
 }
 
-func TestSetNoneDisablesEveryLevel(t *testing.T) {
-	restoreLevel(t)
-	SetLevel(None)
-
+func TestEnabledNoneDisablesEveryLevel(t *testing.T) {
+	lg := New(nil, None)
 	for _, l := range flags {
-		if IsEnabled(l) {
-			t.Errorf("level %d must be disabled after SetLevel(None)", l)
+		if lg.enabled(l) {
+			t.Errorf("level %d must be disabled by None", l)
 		}
 	}
+}
+
+// --- slog emission behavior ---
+
+func TestLogger_PrefilterEmitsOnlyEnabledCategory(t *testing.T) {
+	cap := newCapture()
+	lg := New(slog.New(cap), CommandLevel)
+
+	lg.Commandf("PASS %s", "secret")
+	lg.Serverf("220 ready") // ServerLevel not enabled
+	lg.Passivef("227 ...")  // PassiveLevel not enabled
+	lg.Debugf("trace")      // DebugLevel not enabled
+
+	recs := cap.snapshot()
+	if len(recs) != 1 {
+		t.Fatalf("want exactly 1 record (command only), got %d", len(recs))
+	}
+	if recs[0].Level != slog.LevelDebug {
+		t.Errorf("command should map to LevelDebug, got %v", recs[0].Level)
+	}
+	m := attrMap(recs[0])
+	if m["category"] != "command" {
+		t.Errorf(`want category="command", got %q`, m["category"])
+	}
+	if m["component"] != "zftp" {
+		t.Errorf(`want component="zftp", got %q`, m["component"])
+	}
+	if recs[0].Message != "PASS secret" {
+		t.Errorf("unexpected message %q", recs[0].Message)
+	}
+}
+
+func TestLogger_WarningAndErrorAlwaysEmit(t *testing.T) {
+	cap := newCapture()
+	lg := New(slog.New(cap), None) // nothing in the trace bitmask
+
+	lg.Warningf("w")
+	lg.Errorf("e")
+
+	recs := cap.snapshot()
+	if len(recs) != 2 {
+		t.Fatalf("warning+error must emit regardless of level, got %d", len(recs))
+	}
+	if recs[0].Level != slog.LevelWarn || recs[1].Level != slog.LevelError {
+		t.Errorf("levels: got %v, %v want Warn, Error", recs[0].Level, recs[1].Level)
+	}
+	if attrMap(recs[0])["component"] != "zftp" {
+		t.Error("warning record missing component=zftp")
+	}
+}
+
+func TestLogger_SourcePointsAtCallSite(t *testing.T) {
+	cap := newCapture()
+	lg := New(slog.New(cap), DebugLevel)
+
+	lg.Debugf("x")
+
+	recs := cap.snapshot()
+	if len(recs) != 1 {
+		t.Fatalf("want 1 record, got %d", len(recs))
+	}
+	fs := runtime.CallersFrames([]uintptr{recs[0].PC})
+	f, _ := fs.Next()
+	if !strings.HasSuffix(f.File, "logger_test.go") {
+		t.Errorf("source should be the call site (logger_test.go), got %s:%d", f.File, f.Line)
+	}
+}
+
+func TestLogger_NilSlogUsesDefault(t *testing.T) {
+	cap := newCapture()
+	prev := slog.Default()
+	slog.SetDefault(slog.New(cap))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	lg := New(nil, DebugLevel) // nil ⇒ lazy slog.Default()
+	lg.Debugf("via default")
+
+	if len(cap.snapshot()) != 1 {
+		t.Fatal("nil logger should route to slog.Default()")
+	}
+}
+
+func TestLogger_ConcurrentSwapRace(t *testing.T) {
+	lg := New(slog.New(newCapture()), All)
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				lg.Commandf("c%d", j)
+				lg.SetLevel(All)
+				lg.SetSlog(slog.New(newCapture()))
+			}
+		}()
+	}
+	wg.Wait()
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -79,7 +79,7 @@ const MaxUint32 = 4294967296
 
 // VerifyGzSize verifies that the size of the transferred file matches the size in the gzip footer.
 // This is necessary because the gzip format only supports files up to 2^32 bytes.
-func VerifyGzSize(file *os.File, size int64) error {
+func VerifyGzSize(lg *log.Logger, file *os.File, size int64) error {
 	// Sanity check
 	const footerSize = 4
 	footer := make([]byte, footerSize)
@@ -98,7 +98,7 @@ func VerifyGzSize(file *os.File, size int64) error {
 	have := binary.LittleEndian.Uint32(footer)
 	want := uint32(size % MaxUint32)
 
-	log.Debugf("file %s size=%d, uncompress size: %d, expected size: %d", file.Name(), fileInfo.Size(), have, want)
+	lg.Debugf("file %s size=%d, uncompress size: %d, expected size: %d", file.Name(), fileInfo.Size(), have, want)
 
 	if have != want {
 		return fmt.Errorf("transferred file size doesn't match the size in gzip footer (expected %d, got %d)", have, want)
@@ -162,9 +162,10 @@ type SetRestorer struct {
 	orig string
 	set  func(string) error
 	get  func() (string, error)
+	lg   *log.Logger
 }
 
-func SetValueAndGetCurrent(value string, set func(string) error, get func() (string, error)) (*SetRestorer, error) {
+func SetValueAndGetCurrent(lg *log.Logger, value string, set func(string) error, get func() (string, error)) (*SetRestorer, error) {
 	orig, err := get()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get current value: %w", err)
@@ -179,12 +180,13 @@ func SetValueAndGetCurrent(value string, set func(string) error, get func() (str
 		orig: orig,
 		set:  set,
 		get:  get,
+		lg:   lg,
 	}, nil
 }
 
 func (f *SetRestorer) Restore() {
 	err := f.set(f.orig)
 	if err != nil {
-		log.Warning(err)
+		f.lg.Warning(err)
 	}
 }

--- a/jes.go
+++ b/jes.go
@@ -35,7 +35,7 @@ func (s *FTPSession) SubmitIO(jr io.Reader, options ...JesSpec) (*JesJob, error)
 		}
 	}
 
-	curr, err := utils.SetValueAndGetCurrent("JES", s.SetStatusOf().FileType, s.StatusOf().FileType)
+	curr, err := utils.SetValueAndGetCurrent(s.log, "JES", s.SetStatusOf().FileType, s.StatusOf().FileType)
 	if err != nil {
 		return nil, err
 	}
@@ -89,7 +89,7 @@ var (
 // it returns the whole Spool output as a string
 // this function waits for the job to complete
 func (s *FTPSession) SubmitJesGetByDSN(jcl string) (*JobResult, error) {
-	currSeq, err := utils.SetValueAndGetCurrent("SEQ", s.SetStatusOf().FileType, s.StatusOf().FileType)
+	currSeq, err := utils.SetValueAndGetCurrent(s.log, "SEQ", s.SetStatusOf().FileType, s.StatusOf().FileType)
 	if err != nil {
 		return nil, err
 	}
@@ -109,13 +109,13 @@ func (s *FTPSession) SubmitJesGetByDSN(jcl string) (*JobResult, error) {
 		return nil, fmt.Errorf("failed to write JCL to FTP server: %w", err)
 	}
 
-	currJes, err := utils.SetValueAndGetCurrent("JES NOJESGETBYDSN", s.SetStatusOf().FileType, s.StatusOf().FileType)
+	currJes, err := utils.SetValueAndGetCurrent(s.log, "JES NOJESGETBYDSN", s.SetStatusOf().FileType, s.StatusOf().FileType)
 	if err != nil {
 		return nil, err
 	}
 	defer currJes.Restore()
 
-	currName, err := utils.SetValueAndGetCurrent("*", s.SetStatusOf().JesJobName, s.StatusOf().JesJobName)
+	currName, err := utils.SetValueAndGetCurrent(s.log, "*", s.SetStatusOf().JesJobName, s.StatusOf().JesJobName)
 	if err != nil {
 		return nil, err
 	}
@@ -228,14 +228,14 @@ func (s *FTPSession) GetJobStatus(jobID string) (*hfs.InfoJobDetail, error) {
 	}
 
 	// set JES parameters and restore them after the function returns
-	FileType, err := utils.SetValueAndGetCurrent("JES", s.SetStatusOf().FileType, s.StatusOf().FileType)
+	FileType, err := utils.SetValueAndGetCurrent(s.log, "JES", s.SetStatusOf().FileType, s.StatusOf().FileType)
 	if err != nil {
 		return nil, err
 	}
 	defer FileType.Restore()
 
 	// set jes job name to * and restore it after the function returns
-	JesJobName, err := utils.SetValueAndGetCurrent("*", s.SetStatusOf().JesJobName, s.StatusOf().JesJobName)
+	JesJobName, err := utils.SetValueAndGetCurrent(s.log, "*", s.SetStatusOf().JesJobName, s.StatusOf().JesJobName)
 	if err != nil {
 		return nil, err
 	}

--- a/jes_test.go
+++ b/jes_test.go
@@ -164,7 +164,6 @@ func TestSubmitLISTDS(t *testing.T) {
 }
 
 func TestSubmitDITTO(t *testing.T) {
-	//log.SetLevel(log.All)
 	requireEnv(t)
 	// Create a new FTP session
 	s, err := zftp.Open(hostname)

--- a/lists.go
+++ b/lists.go
@@ -107,7 +107,7 @@ func (s *FTPSession) NList(expression string) ([]string, error) {
 // ListDatasets returns a list of files matching the given expression, including file attributes.
 func (s *FTPSession) ListDatasets(expression string) ([]hfs.InfoDataset, error) {
 
-	curr, err := utils.SetValueAndGetCurrent("SEQ", s.SetStatusOf().FileType, s.StatusOf().FileType)
+	curr, err := utils.SetValueAndGetCurrent(s.log, "SEQ", s.SetStatusOf().FileType, s.StatusOf().FileType)
 	if err != nil {
 		return nil, err
 	}
@@ -134,7 +134,7 @@ func (s *FTPSession) ListDatasets(expression string) ([]hfs.InfoDataset, error) 
 // ListPds returns a list of files matching the given expression, including file attributes.
 func (s *FTPSession) ListPds(expression string) ([]hfs.InfoPdsMember, error) {
 
-	curr, err := utils.SetValueAndGetCurrent("SEQ", s.SetStatusOf().FileType, s.StatusOf().FileType)
+	curr, err := utils.SetValueAndGetCurrent(s.log, "SEQ", s.SetStatusOf().FileType, s.StatusOf().FileType)
 	if err != nil {
 		return nil, err
 	}
@@ -169,7 +169,7 @@ func (s *FTPSession) ListSpool(expression string) ([]hfs.InfoJob, error) {
 		return nil, fmt.Errorf("invalid search pattern: %s", expression)
 	}
 
-	curr, err := utils.SetValueAndGetCurrent("JES", s.SetStatusOf().FileType, s.StatusOf().FileType)
+	curr, err := utils.SetValueAndGetCurrent(s.log, "JES", s.SetStatusOf().FileType, s.StatusOf().FileType)
 	if err != nil {
 		return nil, err
 	}

--- a/lists.go
+++ b/lists.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"gopkg.in/ro-ag/zftp.v2/hfs"
-	"gopkg.in/ro-ag/zftp.v2/internal/log"
 	"gopkg.in/ro-ag/zftp.v2/internal/utils"
 	"strings"
 )
@@ -22,7 +21,8 @@ func (s *FTPSession) anyList(cmd, expression string) ([]string, string, error) {
 	case "NLST":
 		trimLine = true
 	default:
-		log.Panicf("invalid command: %s", cmd)
+		s.log.Errorf("invalid command: %s", cmd)
+		panic(fmt.Sprintf("invalid command: %s", cmd))
 	}
 
 	current := s.currentType()
@@ -33,7 +33,7 @@ func (s *FTPSession) anyList(cmd, expression string) ([]string, string, error) {
 		}
 		defer func() {
 			if err := s.SetType(current); err != nil {
-				log.Error(err)
+				s.log.Error(err)
 			}
 		}()
 	}
@@ -49,7 +49,7 @@ func (s *FTPSession) anyList(cmd, expression string) ([]string, string, error) {
 	}
 	defer func(child *childConnection) {
 		if err := child.Close(); err != nil {
-			log.Error(err)
+			s.log.Error(err)
 		}
 	}(child)
 
@@ -66,7 +66,7 @@ func (s *FTPSession) anyList(cmd, expression string) ([]string, string, error) {
 			line = strings.TrimSpace(line)
 		}
 		lines = append(lines, line)
-		log.Passivef("%s", line)
+		s.log.Passivef("%s", line)
 	}
 
 	// Classify why the scan stopped before trusting the result. A concurrent close

--- a/log_test.go
+++ b/log_test.go
@@ -10,7 +10,7 @@ import (
 
 // TestLogLevelMirrorsInternal guards the invariant that the public LogLevel
 // constants carry the exact bit values of internal/log.Level. SetVerbose maps
-// one onto the other with a plain cast (log.SetLevel(log.Level(level))), so any
+// one onto the other with a plain cast (s.log.SetLevel(log.Level(level))), so any
 // drift between the two blocks would silently mis-route logging categories.
 func TestLogLevelMirrorsInternal(t *testing.T) {
 	cases := []struct {

--- a/logger_session_test.go
+++ b/logger_session_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package zftp
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+
+	ilog "gopkg.in/ro-ag/zftp.v2/internal/log"
+)
+
+// capHandler counts the records it handles, bucketed by their category attribute.
+type capHandler struct {
+	mu   sync.Mutex
+	cats []string
+}
+
+func (c *capHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (c *capHandler) Handle(_ context.Context, r slog.Record) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	r.Attrs(func(a slog.Attr) bool {
+		if a.Key == "category" {
+			c.cats = append(c.cats, a.Value.String())
+		}
+		return true
+	})
+	return nil
+}
+
+func (c *capHandler) WithAttrs([]slog.Attr) slog.Handler { return c }
+func (c *capHandler) WithGroup(string) slog.Handler      { return c }
+
+func (c *capHandler) count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.cats)
+}
+
+// Two sessions, different loggers and levels, must not cross-talk.
+func TestPerSessionLoggerIsolation(t *testing.T) {
+	a, b := &capHandler{}, &capHandler{}
+
+	s1 := newSession(nil, dialOptions{})
+	s1.SetLogger(slog.New(a))
+	s1.SetVerbose(LogCommand)
+
+	s2 := newSession(nil, dialOptions{})
+	s2.SetLogger(slog.New(b))
+	s2.SetVerbose(NoLog)
+
+	s1.log.Commandf("PASS x")
+	s2.log.Commandf("PASS y") // s2 has NoLog ⇒ suppressed
+
+	if a.count() != 1 {
+		t.Errorf("session 1 should have 1 command record, got %d", a.count())
+	}
+	if b.count() != 0 {
+		t.Errorf("session 2 (NoLog) should capture nothing, got %d", b.count())
+	}
+}
+
+// WithLogger wires the option through the construction path (newSession).
+func TestWithLoggerOption(t *testing.T) {
+	h := &capHandler{}
+	var cfg dialOptions
+	cfg.apply([]Option{WithLogger(slog.New(h))})
+	s := newSession(nil, cfg)
+	s.SetVerbose(LogServer)
+
+	s.log.Serverf("220 ready")
+	if h.count() != 1 {
+		t.Errorf("WithLogger should route Serverf to the handler, got %d", h.count())
+	}
+}
+
+// Default session (no WithLogger, no SetVerbose) is silent.
+func TestDefaultSessionSilent(t *testing.T) {
+	s := newSession(nil, dialOptions{})
+	if s.log == nil {
+		t.Fatal("session logger must be non-nil after newSession")
+	}
+	if s.log.Level() != ilog.None {
+		t.Errorf("default level should be None, got %d", s.log.Level())
+	}
+}

--- a/options.go
+++ b/options.go
@@ -2,7 +2,10 @@
 
 package zftp
 
-import "time"
+import (
+	"log/slog"
+	"time"
+)
 
 // Option configures behavior for Open and passive connections.
 type Option func(*dialOptions)
@@ -14,6 +17,7 @@ type dialOptions struct {
 	ReplyTimeout    time.Duration
 	dialer          Dialer
 	signalHandler   bool
+	logger          *slog.Logger
 }
 
 // defaultReplyTimeout bounds the wait for a post-transfer control reply. It is
@@ -75,4 +79,13 @@ func WithKeepAlive(d time.Duration) Option {
 // restores the default.
 func WithReplyTimeout(d time.Duration) Option {
 	return func(o *dialOptions) { o.ReplyTimeout = d }
+}
+
+// WithLogger routes this session's logs into l, a *slog.Logger. zftp emits its
+// trace categories (selected with SetVerbose) at slog.LevelDebug, warnings at
+// LevelWarn and errors at LevelError, each tagged with component="zftp" and trace
+// lines with a category attribute. A nil l selects slog.Default(). To bridge zap
+// or zerolog, wrap them in their respective slog.Handler.
+func WithLogger(l *slog.Logger) Option {
+	return func(o *dialOptions) { o.logger = l }
 }

--- a/passive.go
+++ b/passive.go
@@ -84,6 +84,7 @@ type childConnection struct {
 	maps     *sync.Map
 	scan     *scanner
 	isClosed atomic.Bool
+	lg       *log.Logger
 }
 
 // Close tears down the data connection. It is idempotent and safe to call
@@ -95,7 +96,7 @@ func (c *childConnection) Close() error {
 	// Flip the closed flag first (atomically) so concurrent closes are mutually
 	// exclusive and any in-flight scan/read sees the closure immediately.
 	if c.isClosed.Swap(true) {
-		log.Debugf("<%s> child connection already closed: %s = %p", caller, c.RemoteAddr().String(), c)
+		c.lg.Debugf("<%s> child connection already closed: %s = %p", caller, c.RemoteAddr().String(), c)
 		return nil
 	}
 
@@ -104,7 +105,7 @@ func (c *childConnection) Close() error {
 	_ = c.Conn.SetDeadline(time.Now())
 
 	if _, ok := c.maps.Load(c.RemoteAddr().String()); !ok {
-		log.Debugf("<%s>: child connection not present in map: %p", caller, c)
+		c.lg.Debugf("<%s>: child connection not present in map: %p", caller, c)
 	}
 
 	err := c.Conn.Close()
@@ -113,7 +114,7 @@ func (c *childConnection) Close() error {
 	}
 	c.maps.Delete(c.RemoteAddr().String())
 
-	log.Debugf("closed child connection: %s = %p", c.RemoteAddr().String(), c)
+	c.lg.Debugf("closed child connection: %s = %p", c.RemoteAddr().String(), c)
 	return err
 }
 
@@ -139,7 +140,7 @@ func (s *FTPSession) newChildConnection(port int) (*childConnection, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	log.Debugf("attempting to create a new connection with port %d", port)
+	s.log.Debugf("attempting to create a new connection with port %d", port)
 
 	address := s.conn.RemoteAddr().String()
 	// Split the address into IP/hostname and port
@@ -167,14 +168,14 @@ func (s *FTPSession) newChildConnection(port int) (*childConnection, error) {
 
 	if s.tlsConfig != nil {
 		conn = tls.Client(conn, s.tlsConfig)
-		log.Debugf("upgraded connection to TLS")
+		s.log.Debugf("upgraded connection to TLS")
 	}
 
-	child := &childConnection{Conn: conn, parent: conn.RemoteAddr(), maps: &s.dataConns}
+	child := &childConnection{Conn: conn, parent: conn.RemoteAddr(), maps: &s.dataConns, lg: s.log}
 	child.scan = newScanner(conn, child.IsClosed)
 	s.dataConns.Store(child.RemoteAddr().String(), child)
 
-	log.Debugf("created child connection: %s", child.RemoteAddr().String())
+	s.log.Debugf("created child connection: %s", child.RemoteAddr().String())
 	return child, nil
 }
 

--- a/put.go
+++ b/put.go
@@ -4,7 +4,6 @@ package zftp
 
 import (
 	"fmt"
-	"gopkg.in/ro-ag/zftp.v2/internal/log"
 	"gopkg.in/ro-ag/zftp.v2/internal/utils"
 	"io"
 	"os"
@@ -24,14 +23,14 @@ const (
 func (s *FTPSession) Put(srcLocal string, destRemote string, mode TransferType, a ...DataSpec) error {
 
 	if len(a) > 0 {
-		log.Debug("dataset attributes passed to Put()")
+		s.log.Debug("dataset attributes passed to Put()")
 		err := s.SetDataSpecs(a...)
 		if err != nil {
 			return err
 		}
 	}
 
-	log.Debugf("attempting to open source file: %s", srcLocal)
+	s.log.Debugf("attempting to open source file: %s", srcLocal)
 
 	file, err := os.Open(srcLocal)
 	if err != nil {
@@ -40,28 +39,28 @@ func (s *FTPSession) Put(srcLocal string, destRemote string, mode TransferType, 
 
 	defer func() {
 		if cerr := file.Close(); cerr != nil {
-			log.Errorf("failed to close file: %s", cerr)
+			s.log.Errorf("failed to close file: %s", cerr)
 		}
 	}()
 
 	fileInfo, err := file.Stat()
 	if err != nil {
-		log.Error("Failed to get file stats for:", srcLocal)
+		s.log.Error("Failed to get file stats for:", srcLocal)
 		return err
 	}
-	log.Debugf("file stats for %s :", srcLocal)
-	log.Debugf("   - size in bytes     : %d", fileInfo.Size())
-	log.Debugf("   - file mode         : %s", fileInfo.Mode())
-	log.Debugf("   - modification time : %s", fileInfo.ModTime())
+	s.log.Debugf("file stats for %s :", srcLocal)
+	s.log.Debugf("   - size in bytes     : %d", fileInfo.Size())
+	s.log.Debugf("   - file mode         : %s", fileInfo.Mode())
+	s.log.Debugf("   - modification time : %s", fileInfo.ModTime())
 
-	log.Debugf("starting transfer to: %s", destRemote)
+	s.log.Debugf("starting transfer to: %s", destRemote)
 
 	bytesTransferred, _, err := s.StoreIO(destRemote, file, mode)
 	if err != nil {
 		return fmt.Errorf("failed to store file: %w", err)
 	}
 
-	log.Debugf("successfully transferred %d bytes to %s", bytesTransferred, destRemote)
+	s.log.Debugf("successfully transferred %d bytes to %s", bytesTransferred, destRemote)
 
 	return nil
 }
@@ -80,13 +79,13 @@ func (s *FTPSession) PutAt(srcLocal string, destRemote string, mode TransferType
 	}
 
 	if len(a) > 0 {
-		log.Debug("dataset attributes passed to PutAt()")
+		s.log.Debug("dataset attributes passed to PutAt()")
 		if err := s.SetDataSpecs(a...); err != nil {
 			return err
 		}
 	}
 
-	log.Debugf("attempting to open source file: %s", srcLocal)
+	s.log.Debugf("attempting to open source file: %s", srcLocal)
 
 	file, err := os.Open(srcLocal)
 	if err != nil {
@@ -100,28 +99,28 @@ func (s *FTPSession) PutAt(srcLocal string, destRemote string, mode TransferType
 
 	defer func() {
 		if cerr := file.Close(); cerr != nil {
-			log.Errorf("failed to close file: %s", cerr)
+			s.log.Errorf("failed to close file: %s", cerr)
 		}
 	}()
 
 	fileInfo, err := file.Stat()
 	if err != nil {
-		log.Error("Failed to get file stats for:", srcLocal)
+		s.log.Error("Failed to get file stats for:", srcLocal)
 		return err
 	}
-	log.Debugf("file stats for %s :", srcLocal)
-	log.Debugf("   - size in bytes     : %d", fileInfo.Size())
-	log.Debugf("   - file mode         : %s", fileInfo.Mode())
-	log.Debugf("   - modification time : %s", fileInfo.ModTime())
+	s.log.Debugf("file stats for %s :", srcLocal)
+	s.log.Debugf("   - size in bytes     : %d", fileInfo.Size())
+	s.log.Debugf("   - file mode         : %s", fileInfo.Mode())
+	s.log.Debugf("   - modification time : %s", fileInfo.ModTime())
 
-	log.Debugf("starting transfer to: %s at offset %d", destRemote, offset)
+	s.log.Debugf("starting transfer to: %s at offset %d", destRemote, offset)
 
 	bytesTransferred, _, err := s.StoreIOAt(destRemote, file, mode, offset)
 	if err != nil {
 		return fmt.Errorf("failed to store file: %w", err)
 	}
 
-	log.Debugf("successfully transferred %d bytes to %s", bytesTransferred, destRemote)
+	s.log.Debugf("successfully transferred %d bytes to %s", bytesTransferred, destRemote)
 
 	return nil
 }
@@ -242,7 +241,7 @@ func (s *FTPSession) SetDataSpecs(attributes ...DataSpec) error {
 		return err
 	}
 	if msg != "SITE command was accepted" {
-		log.Warning(utils.WrapText(msg))
+		s.log.Warning(utils.WrapText(msg))
 	}
 	return nil
 }

--- a/transfer.go
+++ b/transfer.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"gopkg.in/ro-ag/zftp.v2/eol"
-	"gopkg.in/ro-ag/zftp.v2/internal/log"
 	"gopkg.in/ro-ag/zftp.v2/internal/transfer"
 	"io"
 )
@@ -109,7 +108,7 @@ func (s *FTPSession) transfer(t transfer.DataTransfer, remote string, offset int
 	defer func(child *childConnection) {
 		if !child.IsClosed() {
 			if err = child.Close(); err != nil {
-				log.Error(err)
+				s.log.Error(err)
 			}
 		}
 	}(child)


### PR DESCRIPTION
Closes #57

Replaces the process-global `internal/log` singleton with a per-session `*slog.Logger`.

## What
- **`internal/log`** is now a `Logger` value type wrapping a `*slog.Logger` + the ZH06 category bitmask. Trace categories (Server/Passive/Command/Debug, selected by `SetVerbose`) emit at `slog.LevelDebug` with a `category` attribute; `Warning`→`Warn`, `Error`→`Error`. Every record is tagged `component=zftp`. Caller source captured via `runtime.Callers`.
- **Per session:** `*FTPSession` owns a `log *log.Logger`; no global mutable logging state remains.
- **Public API:** `WithLogger(*slog.Logger) Option` (open-time) + `(*FTPSession).SetLogger(*slog.Logger)` (runtime). No injection ⇒ lazy `slog.Default()`. `SetVerbose`/`LogLevel` source-compatible (now per-session).
- **Zero-dep core:** stdlib `log/slog` only. zap (`zapslog`) and zerolog (a zerolog→slog handler) bridge in the user app.
- ~60 call sites migrated; non-method helpers thread a `*log.Logger` (`parseCommand`, `ReturnCode.check`, `childConnection.lg`, `internal/utils`).

## Breaking (pre-ship, approved)
- **Go floor 1.20 → 1.26** (both `go.mod` and `cli/go.mod`). slog needs ≥1.21, but Go 1.21 `-race`/CGO binaries hit a macOS dyld "missing LC_UUID" loader bug (fixed in 1.22+); the floor was set to the current Go (1.26) so the full race matrix is green with no per-leg exclusions. CI matrix bumped to `["1.26","stable"]`.
- Log output is now structured slog records (format change). Internal global log API + stdlib-shaped `Logger` interface removed (internal only).
- `lists.go` invalid-command guard: `log.Panicf` → `Error` + `panic`.

## Tests (TDD, `-race`)
- `internal/log/logger_test.go`: prefilter isolation, level mapping, `component`/`category` attrs, always-on Warn/Error, nil⇒default, caller source, concurrent swap; ZH06 bit invariants retained.
- `logger_session_test.go`: per-session isolation (two sessions, independent loggers/levels), `WithLogger` wiring, default-silent.

## Verification (local + CI, all green)
- `CGO_ENABLED=0 go build ./...`, `go vet ./...`, `staticcheck ./...`, `go test -race ./...`, `govulncheck ./...` — No vulnerabilities found. CI 8/8 on Go 1.26 + stable. Adversarial review: no findings.

Spec: `docs/superpowers/specs/2026-06-22-logger-injection-design.md` · Plan: `docs/superpowers/plans/2026-06-22-logger-injection.md`