### PR TITLE
chore: modernize with Go 1.26 go fix

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -98,7 +98,7 @@ func parseCommand(lg *log.Logger, cmd string, a ...string) []byte {
 		lg.Commandf("%s", command)
 	}
 
-	fullCommand := []byte(fmt.Sprintf("%s %s\r\n", command, args))
+	fullCommand := fmt.Appendf(nil, "%s %s\r\n", command, args)
 
 	return fullCommand
 }

--- a/concurrency_test.go
+++ b/concurrency_test.go
@@ -4,6 +4,7 @@ package zftp_test
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -42,42 +43,34 @@ func TestSession_ConcurrentCommandsAndClose_RaceFree(t *testing.T) {
 		var wg sync.WaitGroup
 
 		// Concurrent control round-trips: each reads the shared control reader.
-		for i := 0; i < 8; i++ {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+		for range 8 {
+			wg.Go(func() {
 				_, _ = s.SendCommand(zftp.CodeCmdOK, "NOOP")
-			}()
+			})
 		}
 
 		// Concurrent passive-mode negotiations (PASV round-trip + parse).
-		for i := 0; i < 4; i++ {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+		for range 4 {
+			wg.Go(func() {
 				_, _ = s.SetPassiveMode()
-			}()
+			})
 		}
 
 		// Concurrent transfer-type writes (exercise the currType field).
-		for i := 0; i < 4; i++ {
+		for i := range 4 {
 			typ := zftp.TypeAscii
 			if i%2 == 1 {
 				typ = zftp.TypeBinary
 			}
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				_ = s.SetType(typ)
-			}()
+			})
 		}
 
 		// A concurrent Close must not race the in-flight commands.
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			_ = s.Close()
-		}()
+		})
 
 		wg.Wait()
 	})
@@ -181,24 +174,20 @@ func TestList_ControlDropClosesSession(t *testing.T) {
 func TestSession_ConcurrentListAndClose_NoPanic(t *testing.T) {
 	s, srv := dialMock(t)
 	// A sizable listing so the data scan is still draining when Close lands.
-	var listing string
-	for i := 0; i < 500; i++ {
-		listing += "FA00FF 3390   2023/06/02  1  360  VB    8004 27998  PS  'ABCD.EF.SEQ'\r\n"
+	var listing strings.Builder
+	for range 500 {
+		listing.WriteString("FA00FF 3390   2023/06/02  1  360  VB    8004 27998  PS  'ABCD.EF.SEQ'\r\n")
 	}
-	srv.DataFor("LIST", "", listing)
+	srv.DataFor("LIST", "", listing.String())
 
 	runWithTimeout(t, 10*time.Second, func() {
 		var wg sync.WaitGroup
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			_, _ = s.List("ABCD.EF.*")
-		}()
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		})
+		wg.Go(func() {
 			_ = s.Close()
-		}()
+		})
 		wg.Wait()
 	})
 }

--- a/data_conn_test.go
+++ b/data_conn_test.go
@@ -128,17 +128,13 @@ func TestSession_ConcurrentRetrieveAndClose_NoPanic(t *testing.T) {
 
 	runWithTimeout(t, 10*time.Second, func() {
 		var wg sync.WaitGroup
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			var buf bytes.Buffer
 			_, _, _ = s.RetrieveIO("BIG.BIN", &buf, zftp.TypeBinary)
-		}()
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		})
+		wg.Go(func() {
 			_ = s.Close()
-		}()
+		})
 		wg.Wait()
 	})
 }

--- a/eol/eol_unix.go
+++ b/eol/eol_unix.go
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 package eol
 

--- a/hfs/attributes_test.go
+++ b/hfs/attributes_test.go
@@ -63,8 +63,8 @@ func TestFieldInt_NoSilentWrap(t *testing.T) {
 		in   string
 		want uint32
 	}{
-		{"70000", 70000},  // 5-char Used column; uint16 wrapped to 4464
-		{"65536", 65536},  // uint16 wrapped to 0, rendered as ""
+		{"70000", 70000},   // 5-char Used column; uint16 wrapped to 4464
+		{"65536", 65536},   // uint16 wrapped to 0, rendered as ""
 		{"999999", 999999}, // 6-char Lrecl/BlkSz column max
 	}
 	for _, tc := range cases {
@@ -90,7 +90,7 @@ func TestFieldInt_OutOfRangeErrors(t *testing.T) {
 	for _, in := range []string{
 		"4294967296", // one past uint32 max
 		"99999999999",
-		"-1",  // counts are non-negative; a leading '-' must not wrap
+		"-1",   // counts are non-negative; a leading '-' must not wrap
 		"12x3", // non-numeric
 	} {
 		var f FieldInt
@@ -146,7 +146,7 @@ func TestFieldInt_JSONRoundTrip(t *testing.T) {
 	}
 }
 
-func mustMarshal(t *testing.T, v interface{}) string {
+func mustMarshal(t *testing.T, v any) string {
 	t.Helper()
 	b, err := json.Marshal(v)
 	if err != nil {

--- a/hfs/dataset.go
+++ b/hfs/dataset.go
@@ -100,7 +100,7 @@ func (d *InfoDataset) String() string {
 
 // Headers returns the headers for the dataset
 func (d *InfoDataset) Headers() []string {
-	t := reflect.TypeOf(*d)
+	t := reflect.TypeFor[InfoDataset]()
 	headers := make([]string, 0, t.NumField())
 	for i := 0; i < t.NumField(); i++ {
 		field := t.Field(i)

--- a/hfs/golden_test.go
+++ b/hfs/golden_test.go
@@ -43,7 +43,7 @@ func assertGolden(t *testing.T, name string, got []byte) {
 	}
 }
 
-func toJSON(t *testing.T, v interface{}) []byte {
+func toJSON(t *testing.T, v any) []byte {
 	t.Helper()
 	b, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {

--- a/hfs/layout.go
+++ b/hfs/layout.go
@@ -27,9 +27,6 @@ func (f field) slice(record string) string {
 	if f.width <= 0 {
 		return record[f.start:]
 	}
-	end := f.start + f.width
-	if end > len(record) {
-		end = len(record)
-	}
+	end := min(f.start+f.width, len(record))
 	return record[f.start:end]
 }

--- a/hfs/partitioned.go
+++ b/hfs/partitioned.go
@@ -52,10 +52,9 @@ func (m *InfoPdsMember) ToStringSlice() []string {
 
 // Headers returns the headers for the dataset
 func (m *InfoPdsMember) Headers() []string {
-	t := reflect.TypeOf(*m)
+	t := reflect.TypeFor[InfoPdsMember]()
 	headers := make([]string, 0, t.NumField())
-	for i := 0; i < t.NumField(); i++ {
-		field := t.Field(i)
+	for field := range t.Fields() {
 		jsonTag := field.Tag.Get("json")
 		if jsonTag != "" {
 			headers = append(headers, jsonTag)

--- a/internal/log/logger_test.go
+++ b/internal/log/logger_test.go
@@ -81,7 +81,7 @@ func TestLevelsAreDistinctSingleBits(t *testing.T) {
 		t.Errorf("union of the four levels must occupy 4 distinct bits, has %d (union=%d)", got, union)
 	}
 
-	for i := 0; i < len(flags); i++ {
+	for i := range flags {
 		for j := i + 1; j < len(flags); j++ {
 			if flags[i]&flags[j] != 0 {
 				t.Errorf("levels %d and %d overlap (AND=%d)", flags[i], flags[j], flags[i]&flags[j])
@@ -230,16 +230,14 @@ func TestLogger_NilSlogUsesDefault(t *testing.T) {
 func TestLogger_ConcurrentSwapRace(t *testing.T) {
 	lg := New(slog.New(newCapture()), All)
 	var wg sync.WaitGroup
-	for i := 0; i < 8; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for j := 0; j < 200; j++ {
+	for range 8 {
+		wg.Go(func() {
+			for j := range 200 {
 				lg.Commandf("c%d", j)
 				lg.SetLevel(All)
 				lg.SetSlog(slog.New(newCapture()))
 			}
-		}()
+		})
 	}
 	wg.Wait()
 }

--- a/internal/mockzos/server.go
+++ b/internal/mockzos/server.go
@@ -95,11 +95,9 @@ func (s *Server) serve() {
 		if err != nil {
 			return // listener closed
 		}
-		s.wg.Add(1)
-		go func() {
-			defer s.wg.Done()
+		s.wg.Go(func() {
 			s.handle(conn)
-		}()
+		})
 	}
 }
 
@@ -303,8 +301,8 @@ func (s *Server) acceptData(sess *session) net.Conn {
 // splitCommand splits a request line into an uppercased verb and its argument.
 func splitCommand(line string) (verb, arg string) {
 	line = strings.TrimSpace(line)
-	if i := strings.IndexByte(line, ' '); i >= 0 {
-		return strings.ToUpper(line[:i]), strings.TrimSpace(line[i+1:])
+	if before, after, ok := strings.Cut(line, " "); ok {
+		return strings.ToUpper(before), strings.TrimSpace(after)
 	}
 	return strings.ToUpper(line), ""
 }

--- a/xstat_test.go
+++ b/xstat_test.go
@@ -33,8 +33,7 @@ func TestFTPSession_StatusOf(t *testing.T) {
 	tp := reflect.TypeOf(s.StatusOf())
 	vl := reflect.ValueOf(s.StatusOf())
 
-	for i := 0; i < tp.NumMethod(); i++ {
-		method := tp.Method(i)
+	for method := range tp.Methods() {
 		t.Run(method.Name, func(t *testing.T) {
 			fmt.Printf("Calling %s\n", method.Name)
 			function := vl.MethodByName(method.Name)


### PR DESCRIPTION
Closes #59

Applies the Go 1.26 `go fix` modernizers across the module (now that the floor is go 1.26, #58). Two passes + gofmt; behavior-preserving.

## Changes (12 files)
- **any** — `interface{}` → `any` (test helpers)
- **fmtappendf** — `[]byte(fmt.Sprintf(…))` → `fmt.Appendf(nil, …)` (cmd.go)
- **minmax** — manual clamp → `min(…)` (hfs/layout.go)
- **reflecttypefor** — `reflect.TypeOf(*x)` → `reflect.TypeFor[T]()`; reflect range iterators `Type.Fields()`/`Type.Methods()` (hfs, xstat_test)
- **WaitGroup.Go** — `wg.Add(1); go func(){ defer wg.Done(); … }()` → `wg.Go(…)` (mockzos, concurrency/data_conn/logger tests)
- **stringscut / stringsbuilder** — `strings.IndexByte`+slice → `strings.Cut`; concat loop → `strings.Builder` (mockzos)
- **rangeint** — `for i:=0;i<n;i++` → `for range n`
- **plusbuild** — drop obsolete `// +build` (eol)

## Verification (local, all green)
`go build` / `go vet` / `staticcheck` / `go test -race` / `govulncheck` — No vulnerabilities found. cli build OK.

The two imperfect hunks `go fix` can emit both resolved cleanly: a redundant `field := field` disappeared on the 2nd pass; the added `strings` import is genuinely used by the `strings.Builder` fix.