### PR TITLE
fix: System() returns (string, error) instead of panicking (ZH09)

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -154,20 +154,21 @@ func (s *FTPSession) checkLast(expect ReturnCode) (string, error) {
 	return msg, nil
 }
 
-// System get the system type of the FTP server. will panic
-func (s *FTPSession) System() string {
+// System returns the operating-system type reported by the FTP server.
+//
+// When the value is already known — it is cached during Login — it is returned
+// with a nil error and no network round-trip. Otherwise a SYST command is issued
+// and its reply (or the resulting error) is returned. A control-connection or
+// protocol failure is surfaced as an error, never a panic.
+func (s *FTPSession) System() (string, error) {
 	s.mu.Lock()
 	sys := s.system
 	s.mu.Unlock()
 	if sys != "" {
-		return sys
+		return sys, nil
 	}
 
-	system, err := s.SendCommand(CodeSysType, "SYST")
-	if err != nil {
-		panic(err)
-	}
-	return system
+	return s.SendCommand(CodeSysType, "SYST")
 }
 
 // CWD changes the current working directory to the specified path.

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package zftp_test
+
+import (
+	"strings"
+	"testing"
+
+	zftp "gopkg.in/ro-ag/zftp.v2"
+	"gopkg.in/ro-ag/zftp.v2/internal/mockzos"
+)
+
+// countVerb counts how many captured command lines start with the given verb,
+// tolerating the trailing space the client appends to argument-less commands.
+func countVerb(cmds []string, verb string) int {
+	n := 0
+	for _, c := range cmds {
+		if fields := strings.Fields(c); len(fields) > 0 && strings.EqualFold(fields[0], verb) {
+			n++
+		}
+	}
+	return n
+}
+
+// TestSystem_ReturnsCachedValueWithoutRoundTrip verifies that System() serves the
+// value cached during Login and does not issue a second SYST command.
+func TestSystem_ReturnsCachedValueWithoutRoundTrip(t *testing.T) {
+	s, srv := dialMock(t)
+
+	// Login already issued exactly one SYST to learn the system type.
+	systBefore := countVerb(srv.Commands(), "SYST")
+	if systBefore != 1 {
+		t.Fatalf("precondition: Login issued %d SYST commands, want 1", systBefore)
+	}
+
+	got, err := s.System()
+	if err != nil {
+		t.Fatalf("System() error = %v, want nil", err)
+	}
+	if got != "MVS" {
+		t.Errorf("System() = %q, want %q", got, "MVS")
+	}
+	if systAfter := countVerb(srv.Commands(), "SYST"); systAfter != systBefore {
+		t.Errorf("System() issued %d extra SYST command(s); want the cached value with no round-trip", systAfter-systBefore)
+	}
+}
+
+// TestSystem_SYSTFailureReturnsErrorWithoutPanic verifies that a failed SYST is
+// surfaced as an error rather than a panic across the API boundary. The old
+// implementation called panic(err) here.
+func TestSystem_SYSTFailureReturnsErrorWithoutPanic(t *testing.T) {
+	srv := mockzos.New(t)
+	srv.Script("SYST", "500 SYST command not understood")
+
+	// Open without Login so the system type is not cached and System() must hit
+	// the network, where SYST fails with a 5xx reply.
+	s, err := zftp.Open(srv.Addr())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	got, err := s.System()
+	if err == nil {
+		t.Fatalf("System() error = nil, want non-nil on SYST failure (got %q)", got)
+	}
+}


### PR DESCRIPTION
## ZH09 (P1): System() panics on a network error

### Problem
`System()` called `panic(err)` when the `SYST` command failed. A library must not panic across its API boundary on remote/network-controlled input — it forces every embedder to `recover()` or risk a crash.

### Fix
Change the signature to `System() (string, error)`:
- The system type cached during `Login` is returned with a `nil` error and **no** network round-trip.
- Otherwise `SYST` is issued and its reply (or resulting error) is returned.
- Never panics.

Behavior is otherwise unchanged — it still reports the MVS system string. Breaking API change, approved while v2 is untagged. No call sites existed in the library, CLI, examples, or README.

### Tests (TDD, RED→GREEN, under `-race`)
In-process `internal/mockzos` + `dialMock(t)`:
- `TestSystem_ReturnsCachedValueWithoutRoundTrip` — after Login, `System()` returns the cached `"MVS"` with a nil error and issues no extra `SYST` (asserted via `srv.Commands()`).
- `TestSystem_SYSTFailureReturnsErrorWithoutPanic` — a scripted 5xx `SYST` reply makes `System()` return a non-nil error and not panic (would panic under the old behavior → RED).

### Gate (local, all green)
- `CGO_ENABLED=0 go build ./...`
- `CGO_ENABLED=0 go vet ./...`
- `staticcheck ./...` — no findings
- `go test -race ./...`
- `govulncheck ./...` — no vulnerabilities
- `cli/` submodule builds

Closes #61