### PR TITLE
harden: land P1 batch (ZH11/ZH13/ZH10/ZH14/ZH16)

### DIFF
--- a/addr_test.go
+++ b/addr_test.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package zftp_test
+
+import (
+	"testing"
+	"time"
+)
+
+// TestSetKeepAlive_OnTCPConn verifies SetKeepAlive succeeds on the loopback TCP
+// control connection the mock provides (enabling with a period, then disabling).
+func TestSetKeepAlive_OnTCPConn(t *testing.T) {
+	s, _ := dialMock(t)
+
+	if err := s.SetKeepAlive(30 * time.Second); err != nil {
+		t.Fatalf("SetKeepAlive(30s): %v", err)
+	}
+	if err := s.SetKeepAlive(0); err != nil {
+		t.Fatalf("SetKeepAlive(0) (disable): %v", err)
+	}
+}
+
+// TestAddrAccessors verifies the address accessors report the underlying socket's
+// addresses: RemoteAddr matches the server the client dialed and LocalAddr is the
+// non-nil client side. They replace the removed Conn() footgun without exposing
+// Read/Write/Close.
+func TestAddrAccessors(t *testing.T) {
+	s, srv := dialMock(t)
+
+	ra := s.RemoteAddr()
+	if ra == nil {
+		t.Fatal("RemoteAddr() = nil")
+	}
+	if ra.String() != srv.Addr() {
+		t.Errorf("RemoteAddr() = %q, want %q", ra.String(), srv.Addr())
+	}
+
+	la := s.LocalAddr()
+	if la == nil {
+		t.Fatal("LocalAddr() = nil")
+	}
+	if la.Network() != "tcp" {
+		t.Errorf("LocalAddr().Network() = %q, want tcp", la.Network())
+	}
+}

--- a/codes.go
+++ b/codes.go
@@ -58,11 +58,14 @@ const (
 	CodeBadFileName            ReturnCode = 553
 )
 
-// ReturnError is an FTP return code error
+// ReturnError reports that the server answered with an FTP reply whose code was
+// not the one the command expected. It carries the code received (rc), the code
+// wanted (wantRc), the reply text, and optionally an underlying transport cause.
 type ReturnError struct {
 	rc      int
 	message string
 	wantRc  int
+	cause   error // optional underlying transport cause, exposed via Unwrap
 }
 
 // ReturnCode returns the FTP return code
@@ -73,6 +76,37 @@ func (e *ReturnError) ReturnCode() ReturnCode {
 // Error returns the error message
 func (e *ReturnError) Error() string {
 	return fmt.Sprintf("FTP response code: got %d, want %d, message: %s", e.rc, e.wantRc, e.message)
+}
+
+// Is reports whether target is a *ReturnError carrying the same FTP return code.
+// It lets callers match a result by code with errors.Is — for example
+// errors.Is(err, zftp.CodeError(zftp.CodeFileActionNotTakenPerm)) — without
+// unpacking the error or comparing ReturnCode() by hand. The expected code and
+// message are intentionally ignored, so any failure carrying that code matches.
+// Non-*ReturnError targets return false so errors.Is continues on to Unwrap.
+func (e *ReturnError) Is(target error) bool {
+	t, ok := target.(*ReturnError)
+	return ok && t.rc == e.rc
+}
+
+// Unwrap returns the underlying transport cause attached to this error, or nil
+// for a pure protocol error (a well-formed but unexpected FTP reply). When a
+// cause is present — e.g. an io.ErrUnexpectedEOF for a reply cut short by a
+// dropped control stream — errors.Is/errors.As can traverse to it.
+func (e *ReturnError) Unwrap() error {
+	return e.cause
+}
+
+// CodeError returns an error usable only as an errors.Is target: it matches any
+// *ReturnError carrying the given FTP return code. External callers cannot build
+// a *ReturnError directly (its fields are unexported), so this is the supported
+// way to test a result by code:
+//
+//	if errors.Is(err, zftp.CodeError(zftp.CodeFileActionNotTakenPerm)) {
+//		// the server rejected the request with 550
+//	}
+func CodeError(rc ReturnCode) error {
+	return &ReturnError{rc: int(rc), wantRc: int(rc)}
 }
 
 // check reads a (possibly multiline) FTP reply and returns its message.

--- a/codes_returnerror_test.go
+++ b/codes_returnerror_test.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package zftp
+
+import (
+	"errors"
+	"io"
+	"testing"
+)
+
+// TestReturnError_IsByCode verifies a *ReturnError matches, under errors.Is,
+// another *ReturnError carrying the same return code and not one with a different
+// code — letting callers match by code without unpacking the error.
+func TestReturnError_IsByCode(t *testing.T) {
+	err := error(&ReturnError{rc: 550, wantRc: 250, message: "dataset not found"})
+
+	if !errors.Is(err, &ReturnError{rc: 550}) {
+		t.Errorf("errors.Is(err, &ReturnError{rc:550}) = false, want true")
+	}
+	if errors.Is(err, &ReturnError{rc: 551}) {
+		t.Errorf("errors.Is(err, &ReturnError{rc:551}) = true, want false")
+	}
+}
+
+// TestReturnError_UnwrapCause verifies an attached transport cause is reachable
+// via errors.Is/errors.As through ReturnError.Unwrap, while the code match still
+// works — a single error can be both "code 426" and "the connection failed".
+func TestReturnError_UnwrapCause(t *testing.T) {
+	err := error(&ReturnError{rc: 426, wantRc: 226, cause: io.ErrUnexpectedEOF})
+
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Errorf("errors.Is(err, io.ErrUnexpectedEOF) = false, want true (Unwrap cause)")
+	}
+	if !errors.Is(err, &ReturnError{rc: 426}) {
+		t.Errorf("code match lost when a cause is attached")
+	}
+
+	var re *ReturnError
+	if !errors.As(err, &re) || re.ReturnCode() != 426 {
+		t.Errorf("errors.As to *ReturnError failed; got %v", re)
+	}
+}
+
+// TestCodeError_TargetByCode verifies the exported CodeError builds an errors.Is
+// target so external callers (which cannot construct a *ReturnError with its
+// unexported fields) can still match by code.
+func TestCodeError_TargetByCode(t *testing.T) {
+	err := error(&ReturnError{rc: 550, wantRc: 250})
+
+	if !errors.Is(err, CodeError(CodeFileActionNotTakenPerm)) { // 550
+		t.Errorf("errors.Is(err, CodeError(550)) = false, want true")
+	}
+	if errors.Is(err, CodeError(CodeBadFileName)) { // 553
+		t.Errorf("errors.Is(err, CodeError(553)) = true, want false")
+	}
+}
+
+// TestReturnError_NoCauseUnwrapNil documents that a pure protocol error has no
+// cause: Unwrap returns nil so errors.Is does not match an unrelated transport
+// error.
+func TestReturnError_NoCauseUnwrapNil(t *testing.T) {
+	err := error(&ReturnError{rc: 550, wantRc: 250})
+	if errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Errorf("a causeless ReturnError must not match io.ErrUnexpectedEOF")
+	}
+	if u := errors.Unwrap(err); u != nil {
+		t.Errorf("Unwrap = %v, want nil", u)
+	}
+}

--- a/codes_test.go
+++ b/codes_test.go
@@ -4,6 +4,7 @@ package zftp_test
 
 import (
 	"errors"
+	"io"
 	"strings"
 	"testing"
 
@@ -43,6 +44,46 @@ func TestSendCommand_ReturnError(t *testing.T) {
 	}
 	if !strings.Contains(re.Error(), "550") || !strings.Contains(re.Error(), "250") {
 		t.Errorf("Error() should mention got/want codes: %q", re.Error())
+	}
+}
+
+// TestSendCommand_CodeErrorMatch verifies a caller can match a real server
+// rejection by code via errors.Is(err, CodeError(rc)) on the live SendCommand
+// path, and that a different code does not match.
+func TestSendCommand_CodeErrorMatch(t *testing.T) {
+	s, srv := dialMock(t)
+	srv.Script("DELE BAD.DSN", "550 dataset not found")
+
+	_, err := s.SendCommand(zftp.CodeFileActionOK, "DELE", "BAD.DSN")
+	if err == nil {
+		t.Fatal("want error for unexpected return code")
+	}
+	if !errors.Is(err, zftp.CodeError(zftp.CodeFileActionNotTakenPerm)) { // 550
+		t.Errorf("errors.Is(err, CodeError(550)) = false, want true: %v", err)
+	}
+	if errors.Is(err, zftp.CodeError(zftp.CodeCmdOK)) { // 200
+		t.Errorf("errors.Is(err, CodeError(200)) = true, want false")
+	}
+}
+
+// TestSendCommand_TransportCauseIsWrapped verifies a transport failure (the peer
+// dropping the control stream) surfaces as a wrapped io.ErrUnexpectedEOF —
+// discoverable with errors.Is — and is NOT a *ReturnError, so a transport failure
+// is distinguishable from a protocol rejection.
+func TestSendCommand_TransportCauseIsWrapped(t *testing.T) {
+	s, srv := dialMock(t)
+	srv.Hangup("NOOP")
+
+	_, err := s.SendCommand(zftp.CodeCmdOK, "NOOP")
+	if err == nil {
+		t.Fatal("want error from a dropped control connection")
+	}
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Errorf("errors.Is(err, io.ErrUnexpectedEOF) = false, want true: %v", err)
+	}
+	var re *zftp.ReturnError
+	if errors.As(err, &re) {
+		t.Errorf("a transport failure must not be a *ReturnError; got %v", re)
 	}
 }
 

--- a/dialer_test.go
+++ b/dialer_test.go
@@ -33,7 +33,7 @@ func TestOpen_WithInjectedDialer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open with injected dialer: %v", err)
 	}
-	if s.Conn() == nil {
+	if s.RemoteAddr() == nil {
 		t.Fatal("session has no connection")
 	}
 	if err := s.Close(); err != nil {

--- a/ftp.go
+++ b/ftp.go
@@ -136,10 +136,41 @@ func (s *FTPSession) SetLogger(l *slog.Logger) {
 	s.log.SetSlog(l)
 }
 
-// Conn exposes the underlying network connection used by the session.
-// This allows the caller to apply custom options such as TCP keep alive.
-func (s *FTPSession) Conn() net.Conn {
-	return s.conn
+// SetKeepAlive enables TCP keep-alive on the underlying control socket with the
+// given idle period, or disables keep-alive when d <= 0. It returns an error if
+// the underlying connection is not a *net.TCPConn (for example, a custom dialer
+// supplied a different net.Conn implementation).
+//
+// Read/write deadlines and Read/Write/Close are deliberately not exposed: the
+// command layer owns deadlines and connection lifecycle, and handing out the raw
+// socket would let callers corrupt the control stream or bypass session
+// bookkeeping. Use RemoteAddr/LocalAddr for the peer/local addresses.
+func (s *FTPSession) SetKeepAlive(d time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	tcp, ok := s.rawConn.(*net.TCPConn)
+	if !ok {
+		return fmt.Errorf("zftp: SetKeepAlive: underlying connection is not a *net.TCPConn (%T)", s.rawConn)
+	}
+	if d <= 0 {
+		return tcp.SetKeepAlive(false)
+	}
+	if err := tcp.SetKeepAlive(true); err != nil {
+		return err
+	}
+	return tcp.SetKeepAlivePeriod(d)
+}
+
+// RemoteAddr returns the remote network address of the underlying control
+// connection (the FTP server), or nil if it is unavailable.
+func (s *FTPSession) RemoteAddr() net.Addr {
+	return s.rawConn.RemoteAddr()
+}
+
+// LocalAddr returns the local network address of the underlying control
+// connection, or nil if it is unavailable.
+func (s *FTPSession) LocalAddr() net.Addr {
+	return s.rawConn.LocalAddr()
 }
 
 // AuthTLS sends the AUTH TLS command to the FTP server and sets up the TLS connection

--- a/hfs/golden_test.go
+++ b/hfs/golden_test.go
@@ -196,22 +196,24 @@ func TestGolden_ParseInfoPdsMember(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 type jobSnapshot struct {
-	Name   string
-	JobId  string
-	Owner  string
-	Status string
-	Class  string
+	Name       string
+	JobId      string
+	Owner      string
+	Status     string
+	Class      string
+	SpoolFiles int
 }
 
 func snapJobs(js []hfs.InfoJob) []jobSnapshot {
 	out := make([]jobSnapshot, len(js))
 	for i := range js {
 		out[i] = jobSnapshot{
-			Name:   js[i].Name.String(),
-			JobId:  js[i].JobId.String(),
-			Owner:  js[i].Owner.String(),
-			Status: js[i].Status.String(),
-			Class:  js[i].Class.String(),
+			Name:       js[i].Name.String(),
+			JobId:      js[i].JobId.String(),
+			Owner:      js[i].Owner.String(),
+			Status:     js[i].Status.String(),
+			Class:      js[i].Class.String(),
+			SpoolFiles: js[i].SpoolFiles,
 		}
 	}
 	return out

--- a/hfs/spool.go
+++ b/hfs/spool.go
@@ -22,10 +22,17 @@ const (
 	jesInterfaceLevel2
 )
 
+// Sentinels reported by InfoJobDetail.ReturnCode (and ParseInfoJobDetail) for a
+// job that has not completed normally. They are returned directly, so callers
+// match them with errors.Is, e.g. errors.Is(err, hfs.ErrAbendedJob).
 var (
-	ErrActiveJob  = errors.New("job is active")
+	// ErrActiveJob indicates the job is still running, so no return code is
+	// available yet.
+	ErrActiveJob = errors.New("job is active")
+	// ErrAbendedJob indicates the job abended (its class reports an ABEND).
 	ErrAbendedJob = errors.New("job abended")
-	ErrJCLError   = errors.New("job has JCL error")
+	// ErrJCLError indicates the job failed with a JCL error.
+	ErrJCLError = errors.New("job has JCL error")
 )
 
 // InfoJob represents a job record from the JES spool.

--- a/hfs/spool.go
+++ b/hfs/spool.go
@@ -36,12 +36,18 @@ var (
 )
 
 // InfoJob represents a job record from the JES spool.
+//
+// SpoolFiles holds the spool-file count reported by a JesInterfaceLevel=1 listing,
+// whose trailing column is "N spool files" rather than a job class. For such
+// records Class is empty and SpoolFiles is N; for JesInterfaceLevel=2 records,
+// which carry a real class, SpoolFiles is 0.
 type InfoJob struct {
-	Name   FieldString `json:"Name"`
-	JobId  FieldString `json:"JobId"`
-	Owner  FieldString `json:"Owner"`
-	Status FieldString `json:"Status"`
-	Class  FieldString `json:"Class"`
+	Name       FieldString `json:"Name"`
+	JobId      FieldString `json:"JobId"`
+	Owner      FieldString `json:"Owner"`
+	Status     FieldString `json:"Status"`
+	Class      FieldString `json:"Class"`
+	SpoolFiles int         `json:"SpoolFiles,omitempty"`
 }
 
 // String returns a row of text representing the job.
@@ -52,6 +58,9 @@ func (j *InfoJob) String() string {
 	str.WriteString(fmt.Sprintf("Owner: %s, ", j.Owner.String()))
 	str.WriteString(fmt.Sprintf("Status: %s, ", j.Status.String()))
 	str.WriteString(fmt.Sprintf("Class: %s", j.Class.String()))
+	if j.SpoolFiles > 0 {
+		str.WriteString(fmt.Sprintf(", SpoolFiles: %d", j.SpoolFiles))
+	}
 	return str.String()
 }
 
@@ -59,26 +68,33 @@ func (j *InfoJob) String() string {
 // Blank lines (common when the raw server response is split on newlines, e.g. a
 // trailing newline) are ignored so callers need not pre-trim the input.
 func ParseInfoJob(records []string) ([]InfoJob, error) {
-	cleaned := make([]string, 0, len(records))
-	for _, r := range records {
+	// Keep each retained line paired with its 1-based position in the ORIGINAL
+	// input, so a parse error reports the real line number rather than the index
+	// after blank lines were filtered out.
+	type lineAt struct {
+		text string
+		orig int
+	}
+	cleaned := make([]lineAt, 0, len(records))
+	for i, r := range records {
 		if strings.TrimSpace(r) != "" {
-			cleaned = append(cleaned, r)
+			cleaned = append(cleaned, lineAt{text: r, orig: i + 1})
 		}
 	}
 	if len(cleaned) == 0 {
 		return nil, fmt.Errorf("no records provided")
 	}
 
-	kind := getInterfaceLevel(cleaned[0])
+	kind := getInterfaceLevel(cleaned[0].text)
 	jobs := make([]InfoJob, 0, len(cleaned))
 
 	for i, record := range cleaned {
 		if i == 0 && kind == jesInterfaceLevel2 {
 			continue
 		}
-		job, err := parseLineJob(record, kind)
+		job, err := parseLineJob(record.text, kind)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse %s record at line %d: %w", jesLevel(kind), i+1, err)
+			return nil, fmt.Errorf("failed to parse %s record at line %d: %w", jesLevel(kind), record.orig, err)
 		}
 		jobs = append(jobs, job)
 	}
@@ -109,9 +125,16 @@ func parseLineJob(line string, level int) (j InfoJob, err error) {
 			return j, fmt.Errorf("failed to parse JobStatus field: %w", err)
 		}
 
-		err = j.Class.parse(fields[3])
+		// A JesInterfaceLevel=1 record has no Class column; its trailing column is
+		// the spool-file count ("N spool files"). Parse the count into SpoolFiles
+		// and leave Class empty.
+		m := numberPrefixRegex.FindStringSubmatch(strings.TrimSpace(fields[3]))
+		if m == nil {
+			return j, fmt.Errorf("failed to parse spool-file count: %q", fields[3])
+		}
+		j.SpoolFiles, err = strconv.Atoi(m[1])
 		if err != nil {
-			return j, fmt.Errorf("failed to parse JobClass field: %w", err)
+			return j, fmt.Errorf("failed to parse spool-file count %q: %w", m[1], err)
 		}
 
 	} else {
@@ -171,6 +194,11 @@ func (j InfoJobDetail) ReturnCode() (rc int, err error) {
 
 	result := regex.FindStringSubmatch(j.job.Class.String())
 	if len(result) != 2 {
+		// An ABEND with no parseable numeric code (e.g. "ABEND S0C4") must still
+		// report ErrAbendedJob rather than a generic "no return code found".
+		if err != nil {
+			return -1, err
+		}
 		return 0, fmt.Errorf("no return code found")
 	}
 
@@ -218,10 +246,26 @@ func ParseInfoJobDetail(records []string) (*InfoJobDetail, error) {
 		return &InfoJobDetail{job: job}, nil
 	}
 
-	job, err := parseLineJob(records[1], kind)
+	// Level 2: records[0] is the column header. Walk the remaining records by
+	// content — skipping blank lines — rather than by fixed offsets, so a stray
+	// blank line does not break parsing. i tracks the position in records, so
+	// detail parse errors still report a 1-based line number (i+1).
+	i := 1
+	skipBlank := func() {
+		for i < len(records) && strings.TrimSpace(records[i]) == "" {
+			i++
+		}
+	}
+
+	skipBlank()
+	if i >= len(records) {
+		return nil, fmt.Errorf("no %s job record found", jesLevel(kind))
+	}
+	job, err := parseLineJob(records[i], kind)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse %s record: %w", jesLevel(kind), err)
 	}
+	i++
 
 	jd := &InfoJobDetail{job: job}
 
@@ -229,41 +273,37 @@ func ParseInfoJobDetail(records []string) (*InfoJobDetail, error) {
 		return jd, ErrActiveJob
 	}
 
-	if len(records) < 3 {
+	// A "--------" separator introduces the detail section; its absence simply
+	// means there is no detail to parse.
+	skipBlank()
+	if i >= len(records) {
 		return jd, nil
 	}
-
-	if !strings.HasPrefix(records[2], "--------") {
-		return jd, fmt.Errorf("cannot get spool detail: '%s'", records[2])
+	if !strings.HasPrefix(records[i], "--------") {
+		return jd, fmt.Errorf("cannot get spool detail: '%s'", records[i])
 	}
+	i++
 
-	if len(records) < 4 {
+	// The detail column header follows the separator.
+	skipBlank()
+	if i >= len(records) {
 		return jd, nil
 	}
-
-	if !strings.Contains(records[3], " ID  STEPNAME PROCSTEP") {
-		return jd, fmt.Errorf("cannot get spool detail: '%s'", records[3])
+	if !strings.Contains(records[i], " ID  STEPNAME PROCSTEP") {
+		return jd, fmt.Errorf("cannot get spool detail: '%s'", records[i])
 	}
-
-	if len(records) < 5 {
-		return jd, nil
-	}
+	i++
 
 	dt := make([]jobDetail, 0)
-
-	for i := 4; i < len(records); i++ {
-		if records[i] == "" {
+	for ; i < len(records); i++ {
+		if strings.TrimSpace(records[i]) == "" {
 			continue
 		}
 
-		if numberPrefixRegex.MatchString(records[i]) {
-			spoolFiles := numberPrefixRegex.FindStringSubmatch(records[i])
-			if len(spoolFiles) != 2 {
-				return jd, fmt.Errorf("failed to parse spool-file count at line %d: %q", i+1, records[i])
-			}
-			n, _ := strconv.Atoi(spoolFiles[1])
+		if m := numberPrefixRegex.FindStringSubmatch(strings.TrimSpace(records[i])); m != nil {
+			n, _ := strconv.Atoi(m[1])
 			if len(dt) != n {
-				return jd, fmt.Errorf("the number of spool files is not equal to the number of records")
+				return jd, fmt.Errorf("spool-file count (%d) does not match the number of detail records (%d)", n, len(dt))
 			}
 			break
 		}

--- a/hfs/spool_robust_test.go
+++ b/hfs/spool_robust_test.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package hfs_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"gopkg.in/ro-ag/zftp.v2/hfs"
+)
+
+// level2Detail builds a JesInterfaceLevel=2 InfoJobDetail from a single job line
+// by prepending the column header the level is detected from.
+func level2Detail(t *testing.T, jobLine string, rest ...string) (*hfs.InfoJobDetail, error) {
+	t.Helper()
+	records := append([]string{
+		"JOBNAME  JOBID    OWNER    STATUS CLASS",
+		jobLine,
+	}, rest...)
+	return hfs.ParseInfoJobDetail(records)
+}
+
+// TestParseInfoJob_Level1_SpoolCount verifies a JesInterfaceLevel=1 listing parses
+// the trailing "N spool files" column into SpoolFiles and leaves Class empty,
+// instead of dumping the spool-file text into Class.
+func TestParseInfoJob_Level1_SpoolCount(t *testing.T) {
+	jobs, err := hfs.ParseInfoJob([]string{"Z33552   TSU06321 OUTPUT  3 spool files"})
+	if err != nil {
+		t.Fatalf("ParseInfoJob: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.SpoolFiles != 3 {
+		t.Errorf("SpoolFiles = %d, want 3", j.SpoolFiles)
+	}
+	if got := j.Class.String(); got != "" {
+		t.Errorf("Class = %q, want empty for a level-1 record", got)
+	}
+	if got := j.Status.String(); got != "OUTPUT" {
+		t.Errorf("Status = %q, want OUTPUT", got)
+	}
+}
+
+// TestReturnCode_AbendWithoutNumericCode verifies an ABEND with no parseable
+// "ABEND=NNN" code (e.g. "ABEND S0C4") still reports ErrAbendedJob instead of a
+// generic "no return code found" — the abend must not be dropped.
+func TestReturnCode_AbendWithoutNumericCode(t *testing.T) {
+	jd, err := level2Detail(t, "MYJOB    JOB00009 Z00000   OUTPUT A        ABEND S0C4")
+	if err != nil {
+		t.Fatalf("ParseInfoJobDetail: %v", err)
+	}
+	if _, err := jd.ReturnCode(); !errors.Is(err, hfs.ErrAbendedJob) {
+		t.Errorf("ReturnCode() err = %v, want ErrAbendedJob", err)
+	}
+}
+
+// TestParseInfoJobDetail_StrayBlankLine verifies a stray blank line in the detail
+// block (here between the job record and the "--------" separator) does not abort
+// parsing: the separator and column header are located by content, not fixed
+// offsets.
+func TestParseInfoJobDetail_StrayBlankLine(t *testing.T) {
+	records := []string{
+		"JOBNAME  JOBID    OWNER    STATUS CLASS",
+		"ANOTHER  JOB06184 Z33500   OUTPUT A        RC=0000",
+		"", // stray blank line
+		"--------",
+		"         ID  STEPNAME PROCSTEP C DDNAME   BYTE-COUNT",
+		"         001 JES2        N/A   A JESMSGLG      1234",
+		"         002 STEP2       N/A   A SYSPRINT       251",
+		"2 spool files",
+	}
+	jd, err := hfs.ParseInfoJobDetail(records)
+	if err != nil {
+		t.Fatalf("ParseInfoJobDetail with stray blank: %v", err)
+	}
+	if got := len(jd.Detail()); got != 2 {
+		t.Errorf("detail count = %d, want 2", got)
+	}
+}
+
+// TestParseInfoJob_ErrorReportsOriginalLine verifies a parse error reports the
+// line number from the ORIGINAL input, not the index after blank lines have been
+// filtered out.
+func TestParseInfoJob_ErrorReportsOriginalLine(t *testing.T) {
+	records := []string{
+		"",                                        // line 1
+		"",                                        // line 2
+		"GOODJOB  JOB00001 OUTPUT  3 spool files", // line 3
+		"BADRECORD",                               // line 4 (malformed)
+	}
+	_, err := hfs.ParseInfoJob(records)
+	if err == nil {
+		t.Fatal("want error for malformed record")
+	}
+	if !strings.Contains(err.Error(), "line 4") {
+		t.Errorf("error should report original input line 4, got: %v", err)
+	}
+}

--- a/hfs/spool_sentinel_test.go
+++ b/hfs/spool_sentinel_test.go
@@ -9,26 +9,30 @@ import (
 	"gopkg.in/ro-ag/zftp.v2/hfs"
 )
 
-// detailFromLine builds an InfoJobDetail from a single JesInterfaceLevel=1 record
-// line (Name JobId Status Class) via the public parser.
-func detailFromLine(t *testing.T, line string) *hfs.InfoJobDetail {
-	t.Helper()
-	d, err := hfs.ParseInfoJobDetail([]string{line})
-	if err != nil {
-		t.Fatalf("ParseInfoJobDetail(%q): %v", line, err)
-	}
-	return d
-}
-
 // TestReturnCode_SentinelsMatchable verifies the hfs sentinels are
-// errors.Is-matchable straight from their producer (ReturnCode): an ACTIVE job
-// yields ErrActiveJob and a JCL-error class yields ErrJCLError. (ErrAbendedJob is
-// covered by the ABEND cases in the ReturnCode robustness tests.)
+// errors.Is-matchable straight from their producers: an ACTIVE job yields
+// ErrActiveJob (returned by ParseInfoJobDetail) and a "JCL error" class yields
+// ErrJCLError (returned by ReturnCode). ErrAbendedJob is covered by the ABEND
+// ReturnCode tests. Records use the JesInterfaceLevel=2 shape (the level that
+// carries Status/Class), detected from the JOBNAME column header.
 func TestReturnCode_SentinelsMatchable(t *testing.T) {
-	if _, err := detailFromLine(t, "MYJOB JOB00001 ACTIVE A").ReturnCode(); !errors.Is(err, hfs.ErrActiveJob) {
+	const header = "JOBNAME  JOBID    OWNER    STATUS CLASS"
+
+	if _, err := hfs.ParseInfoJobDetail([]string{
+		header,
+		"MYJOB    JOB00001 Z00000   ACTIVE A",
+	}); !errors.Is(err, hfs.ErrActiveJob) {
 		t.Errorf("ACTIVE job: err = %v, want ErrActiveJob", err)
 	}
-	if _, err := detailFromLine(t, "MYJOB JOB00002 OUTPUT JCL error").ReturnCode(); !errors.Is(err, hfs.ErrJCLError) {
+
+	jd, err := hfs.ParseInfoJobDetail([]string{
+		header,
+		"MYJOB    JOB00002 Z00000   OUTPUT JCL error",
+	})
+	if err != nil {
+		t.Fatalf("ParseInfoJobDetail: %v", err)
+	}
+	if _, err := jd.ReturnCode(); !errors.Is(err, hfs.ErrJCLError) {
 		t.Errorf("JCL-error class: err = %v, want ErrJCLError", err)
 	}
 }

--- a/hfs/spool_sentinel_test.go
+++ b/hfs/spool_sentinel_test.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package hfs_test
+
+import (
+	"errors"
+	"testing"
+
+	"gopkg.in/ro-ag/zftp.v2/hfs"
+)
+
+// detailFromLine builds an InfoJobDetail from a single JesInterfaceLevel=1 record
+// line (Name JobId Status Class) via the public parser.
+func detailFromLine(t *testing.T, line string) *hfs.InfoJobDetail {
+	t.Helper()
+	d, err := hfs.ParseInfoJobDetail([]string{line})
+	if err != nil {
+		t.Fatalf("ParseInfoJobDetail(%q): %v", line, err)
+	}
+	return d
+}
+
+// TestReturnCode_SentinelsMatchable verifies the hfs sentinels are
+// errors.Is-matchable straight from their producer (ReturnCode): an ACTIVE job
+// yields ErrActiveJob and a JCL-error class yields ErrJCLError. (ErrAbendedJob is
+// covered by the ABEND cases in the ReturnCode robustness tests.)
+func TestReturnCode_SentinelsMatchable(t *testing.T) {
+	if _, err := detailFromLine(t, "MYJOB JOB00001 ACTIVE A").ReturnCode(); !errors.Is(err, hfs.ErrActiveJob) {
+		t.Errorf("ACTIVE job: err = %v, want ErrActiveJob", err)
+	}
+	if _, err := detailFromLine(t, "MYJOB JOB00002 OUTPUT JCL error").ReturnCode(); !errors.Is(err, hfs.ErrJCLError) {
+		t.Errorf("JCL-error class: err = %v, want ErrJCLError", err)
+	}
+}

--- a/hfs/testdata/job_level1.golden.json
+++ b/hfs/testdata/job_level1.golden.json
@@ -4,1399 +4,1599 @@
     "JobId": "TSU06321",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "SMFDUMPS",
     "JobId": "STC06320",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "@@USS2",
     "JobId": "JOB06319",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06318",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "7 spool files"
+    "Class": "",
+    "SpoolFiles": 7
   },
   {
     "Name": "REPRO2",
     "JobId": "JOB06316",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@USS2",
     "JobId": "JOB06315",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "CBLJSONJ",
     "JobId": "JOB06314",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "5 spool files"
+    "Class": "",
+    "SpoolFiles": 5
   },
   {
     "Name": "REPRO2",
     "JobId": "JOB06312",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@USS2",
     "JobId": "JOB06310",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@USS2",
     "JobId": "JOB06309",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "NSPECT5",
     "JobId": "JOB06308",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "5 spool files"
+    "Class": "",
+    "SpoolFiles": 5
   },
   {
     "Name": "@@RACF1",
     "JobId": "JOB06306",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "JES2JOB1",
     "JobId": "JOB06304",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "JES2JOB1",
     "JobId": "JOB06303",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "JCLSETUP",
     "JobId": "JOB06300",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "JES2JOB1",
     "JobId": "JOB06299",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "@@USS2",
     "JobId": "JOB06298",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "CBLJSONJ",
     "JobId": "JOB06296",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "5 spool files"
+    "Class": "",
+    "SpoolFiles": 5
   },
   {
     "Name": "@@USS",
     "JobId": "JOB06295",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "E378859C",
     "JobId": "JOB06284",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@USS",
     "JobId": "JOB06278",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@USS2",
     "JobId": "JOB06277",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@JCL1",
     "JobId": "JOB06274",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@USS2",
     "JobId": "JOB06272",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "E378859C",
     "JobId": "JOB06271",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06270",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "7 spool files"
+    "Class": "",
+    "SpoolFiles": 7
   },
   {
     "Name": "JCLSETUP",
     "JobId": "JOB06269",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "JCLSETUP",
     "JobId": "JOB06267",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06265",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "6 spool files"
+    "Class": "",
+    "SpoolFiles": 6
   },
   {
     "Name": "CBLJSONJ",
     "JobId": "JOB06262",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "5 spool files"
+    "Class": "",
+    "SpoolFiles": 5
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06261",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "7 spool files"
+    "Class": "",
+    "SpoolFiles": 7
   },
   {
     "Name": "REPRO2",
     "JobId": "JOB06260",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "JES2JOB1",
     "JobId": "JOB06259",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06258",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "7 spool files"
+    "Class": "",
+    "SpoolFiles": 7
   },
   {
     "Name": "REPRO2",
     "JobId": "JOB06257",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "REPRO2",
     "JobId": "JOB06256",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "CBLJSONJ",
     "JobId": "JOB06255",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "CBLJSONJ",
     "JobId": "JOB06254",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "5 spool files"
+    "Class": "",
+    "SpoolFiles": 5
   },
   {
     "Name": "REPRO2",
     "JobId": "JOB06252",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@ACLI",
     "JobId": "JOB06251",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "REPRO2",
     "JobId": "JOB06250",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "REPRO2",
     "JobId": "JOB06249",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "JCL3",
     "JobId": "JOB06248",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "JCL3",
     "JobId": "JOB06247",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "REPRO2",
     "JobId": "JOB06246",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "JCL3",
     "JobId": "JOB06244",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "JCL3",
     "JobId": "JOB06243",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "@@ACLI",
     "JobId": "JOB06242",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "JCL3",
     "JobId": "JOB06241",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "@@JCL1",
     "JobId": "JOB06238",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06236",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "7 spool files"
+    "Class": "",
+    "SpoolFiles": 7
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06235",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "7 spool files"
+    "Class": "",
+    "SpoolFiles": 7
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06233",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "7 spool files"
+    "Class": "",
+    "SpoolFiles": 7
   },
   {
     "Name": "@@JCL1",
     "JobId": "JOB06230",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "JCL3",
     "JobId": "JOB06229",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "REPRO2",
     "JobId": "JOB06226",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "JCL3",
     "JobId": "JOB06225",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06224",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "7 spool files"
+    "Class": "",
+    "SpoolFiles": 7
   },
   {
     "Name": "JCL3",
     "JobId": "JOB06223",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "REPRO2",
     "JobId": "JOB06221",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "JCL3",
     "JobId": "JOB06220",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "REPRO2",
     "JobId": "JOB06219",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06217",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "7 spool files"
+    "Class": "",
+    "SpoolFiles": 7
   },
   {
     "Name": "JCL3",
     "JobId": "JOB06216",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06215",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "7 spool files"
+    "Class": "",
+    "SpoolFiles": 7
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06214",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "7 spool files"
+    "Class": "",
+    "SpoolFiles": 7
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06213",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "7 spool files"
+    "Class": "",
+    "SpoolFiles": 7
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06212",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "7 spool files"
+    "Class": "",
+    "SpoolFiles": 7
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06211",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "7 spool files"
+    "Class": "",
+    "SpoolFiles": 7
   },
   {
     "Name": "REPRO2",
     "JobId": "JOB06210",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "PRINT3",
     "JobId": "JOB06209",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "PRINT3",
     "JobId": "JOB06208",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06207",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "7 spool files"
+    "Class": "",
+    "SpoolFiles": 7
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06206",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "7 spool files"
+    "Class": "",
+    "SpoolFiles": 7
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06205",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "7 spool files"
+    "Class": "",
+    "SpoolFiles": 7
   },
   {
     "Name": "JCLSETUP",
     "JobId": "JOB06204",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "PRINT3",
     "JobId": "JOB06202",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "JCLSETUP",
     "JobId": "JOB06201",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "@@FILES1",
     "JobId": "JOB06199",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@AANS2",
     "JobId": "JOB06198",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "CBLJSONJ",
     "JobId": "JOB06197",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "5 spool files"
+    "Class": "",
+    "SpoolFiles": 5
   },
   {
     "Name": "CBLJSONJ",
     "JobId": "JOB06193",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "5 spool files"
+    "Class": "",
+    "SpoolFiles": 5
   },
   {
     "Name": "PDSBUILD",
     "JobId": "JOB06190",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "5 spool files"
+    "Class": "",
+    "SpoolFiles": 5
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06189",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "7 spool files"
+    "Class": "",
+    "SpoolFiles": 7
   },
   {
     "Name": "@@AANS2",
     "JobId": "JOB06188",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06187",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "7 spool files"
+    "Class": "",
+    "SpoolFiles": 7
   },
   {
     "Name": "@@VSC1",
     "JobId": "JOB06185",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "ANOTHER",
     "JobId": "JOB06184",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "HELLO",
     "JobId": "JOB06183",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "HELLO",
     "JobId": "JOB06181",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "HELLO",
     "JobId": "JOB06180",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@JCL1",
     "JobId": "JOB06176",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "HELLO",
     "JobId": "JOB06175",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@JCL1",
     "JobId": "JOB06173",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@AUTO",
     "JobId": "JOB06161",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "CBLJSONJ",
     "JobId": "JOB06160",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "5 spool files"
+    "Class": "",
+    "SpoolFiles": 5
   },
   {
     "Name": "CBLJSONJ",
     "JobId": "JOB06159",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "5 spool files"
+    "Class": "",
+    "SpoolFiles": 5
   },
   {
     "Name": "CBLJSONJ",
     "JobId": "JOB06156",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "5 spool files"
+    "Class": "",
+    "SpoolFiles": 5
   },
   {
     "Name": "CBLJSONJ",
     "JobId": "JOB06152",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@SQL1",
     "JobId": "JOB06143",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "CBLJSONJ",
     "JobId": "JOB06140",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@SQL1",
     "JobId": "JOB06138",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@REXX1",
     "JobId": "JOB06134",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@USS",
     "JobId": "JOB06132",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@RACF1",
     "JobId": "JOB06129",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@USS2",
     "JobId": "JOB06119",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@APDS2",
     "JobId": "JOB06118",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "MERGSORT",
     "JobId": "JOB06117",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@USS2",
     "JobId": "JOB06116",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@APDS1",
     "JobId": "JOB06104",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "PDS1CCAT",
     "JobId": "JOB06102",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "CBLJSONJ",
     "JobId": "JOB06099",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "5 spool files"
+    "Class": "",
+    "SpoolFiles": 5
   },
   {
     "Name": "JCLSETUP",
     "JobId": "JOB06080",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "JCLRESET",
     "JobId": "JOB06079",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "JCL3",
     "JobId": "JOB06073",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "@@ASM1",
     "JobId": "JOB06065",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@JCL1",
     "JobId": "JOB06061",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@CODE",
     "JobId": "JOB06057",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "JCL3",
     "JobId": "JOB06053",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "@@JCL1",
     "JobId": "JOB06051",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "PLICNT",
     "JobId": "JOB06047",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "6 spool files"
+    "Class": "",
+    "SpoolFiles": 6
   },
   {
     "Name": "JCLSETUP",
     "JobId": "JOB06041",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "@@REXX1",
     "JobId": "JOB06038",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "JCL3",
     "JobId": "JOB06036",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "ASMPGM",
     "JobId": "JOB06035",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "5 spool files"
+    "Class": "",
+    "SpoolFiles": 5
   },
   {
     "Name": "JCL3",
     "JobId": "JOB06034",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "@@FILES1",
     "JobId": "JOB06028",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "JCL3",
     "JobId": "JOB06027",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "JCL3",
     "JobId": "JOB06019",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "JCLSETUP",
     "JobId": "JOB06018",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "JCLRESET",
     "JobId": "JOB06017",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "JCL3",
     "JobId": "JOB06015",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "@@GO1",
     "JobId": "JOB06010",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@FILES1",
     "JobId": "JOB06009",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06007",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "7 spool files"
+    "Class": "",
+    "SpoolFiles": 7
   },
   {
     "Name": "NSPECT3",
     "JobId": "JOB06003",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@VSC1",
     "JobId": "JOB06001",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "Z08593B",
     "JobId": "JOB06000",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "5 spool files"
+    "Class": "",
+    "SpoolFiles": 5
   },
   {
     "Name": "@@AUTO",
     "JobId": "JOB05999",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@AUTO",
     "JobId": "JOB05990",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "Z08593A",
     "JobId": "JOB05989",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "5 spool files"
+    "Class": "",
+    "SpoolFiles": 5
   },
   {
     "Name": "@@USS2",
     "JobId": "JOB05984",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "E378859C",
     "JobId": "JOB05982",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@ACLI",
     "JobId": "JOB05978",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@AUTO",
     "JobId": "JOB05977",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "JCL2",
     "JobId": "JOB05972",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "7 spool files"
+    "Class": "",
+    "SpoolFiles": 7
   },
   {
     "Name": "@@JCL1",
     "JobId": "JOB05966",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "JCL3",
     "JobId": "JOB05959",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "@@APDS2",
     "JobId": "JOB05958",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "REPRO2",
     "JobId": "JOB05957",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@CODE",
     "JobId": "JOB05955",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@USS",
     "JobId": "JOB05954",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "JCL2",
     "JobId": "JOB05953",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "7 spool files"
+    "Class": "",
+    "SpoolFiles": 7
   },
   {
     "Name": "@@CODE",
     "JobId": "JOB05947",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@REXX1",
     "JobId": "JOB05948",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "REPRO2",
     "JobId": "JOB05942",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@FILES1",
     "JobId": "JOB05941",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@APDS2",
     "JobId": "JOB05940",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "MERGSORT",
     "JobId": "JOB05934",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "JCLSETUP",
     "JobId": "JOB05931",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "JCLSETUP",
     "JobId": "JOB05929",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "REPRO2",
     "JobId": "JOB05927",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@REXX1",
     "JobId": "JOB05926",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "REPRO2",
     "JobId": "JOB05925",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@APDS1",
     "JobId": "JOB05924",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "PDS1CCAT",
     "JobId": "JOB05916",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@VSC1",
     "JobId": "JOB05914",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "PDSBUILD",
     "JobId": "JOB05910",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "5 spool files"
+    "Class": "",
+    "SpoolFiles": 5
   },
   {
     "Name": "@@APDS1",
     "JobId": "JOB05909",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@SQL1",
     "JobId": "JOB05908",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@FILES1",
     "JobId": "JOB05907",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "PDS1CCAT",
     "JobId": "JOB05905",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@APDS2",
     "JobId": "JOB05886",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@JCL2",
     "JobId": "JOB05885",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "JCLSETUP",
     "JobId": "JOB05884",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "JES2JOB1",
     "JobId": "JOB05881",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "MERGSORT",
     "JobId": "JOB05879",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "PDSBUILD",
     "JobId": "JOB05876",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "5 spool files"
+    "Class": "",
+    "SpoolFiles": 5
   },
   {
     "Name": "JES2JOB1",
     "JobId": "JOB05874",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "JCLSETUP",
     "JobId": "JOB05868",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "JCLRESET",
     "JobId": "JOB05867",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "JCLSETUP",
     "JobId": "JOB05863",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "JCLRESET",
     "JobId": "JOB05862",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@FILES1",
     "JobId": "JOB05858",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "JCLSETUP",
     "JobId": "JOB05857",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "@@USS2",
     "JobId": "JOB05851",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "PDSBUILD",
     "JobId": "JOB05847",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "5 spool files"
+    "Class": "",
+    "SpoolFiles": 5
   },
   {
     "Name": "@@ACBLH",
     "JobId": "JOB05845",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@JCL1",
     "JobId": "JOB05843",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "CBLJSONJ",
     "JobId": "JOB05840",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "5 spool files"
+    "Class": "",
+    "SpoolFiles": 5
   },
   {
     "Name": "JCL3",
     "JobId": "JOB05839",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "@@SQL1",
     "JobId": "JOB05829",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@CODE",
     "JobId": "JOB05827",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@SQL1",
     "JobId": "JOB05823",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@AUTO",
     "JobId": "JOB05821",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "JCL3",
     "JobId": "JOB05811",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "3 spool files"
+    "Class": "",
+    "SpoolFiles": 3
   },
   {
     "Name": "@@USS",
     "JobId": "JOB05799",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "@@FILES1",
     "JobId": "JOB05795",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   },
   {
     "Name": "JCL2",
     "JobId": "JOB05793",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "7 spool files"
+    "Class": "",
+    "SpoolFiles": 7
   },
   {
     "Name": "@@USS",
     "JobId": "JOB05779",
     "Owner": "",
     "Status": "OUTPUT",
-    "Class": "4 spool files"
+    "Class": "",
+    "SpoolFiles": 4
   }
 ]

--- a/hfs/testdata/job_level2.golden.json
+++ b/hfs/testdata/job_level2.golden.json
@@ -4,1399 +4,1599 @@
     "JobId": "TSU06321",
     "Owner": "Z33552",
     "Status": "OUTPUT",
-    "Class": "TSU      ABEND=222 3 spool files"
+    "Class": "TSU      ABEND=222 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "SMFDUMPS",
     "JobId": "STC06320",
     "Owner": "STCOPER",
     "Status": "OUTPUT",
-    "Class": "STC      RC=0000 3 spool files"
+    "Class": "STC      RC=0000 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@USS2",
     "JobId": "JOB06319",
     "Owner": "Z33792",
     "Status": "OUTPUT",
-    "Class": "A        RC=0127 4 spool files"
+    "Class": "A        RC=0127 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06318",
     "Owner": "Z33935",
     "Status": "OUTPUT",
-    "Class": "A        ABEND=000 7 spool files"
+    "Class": "A        ABEND=000 7 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "REPRO2",
     "JobId": "JOB06316",
     "Owner": "Z33649",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@USS2",
     "JobId": "JOB06315",
     "Owner": "Z33792",
     "Status": "OUTPUT",
-    "Class": "A        RC=0127 4 spool files"
+    "Class": "A        RC=0127 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "CBLJSONJ",
     "JobId": "JOB06314",
     "Owner": "Z32883",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 5 spool files"
+    "Class": "A        RC=0000 5 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "REPRO2",
     "JobId": "JOB06312",
     "Owner": "Z33649",
     "Status": "OUTPUT",
-    "Class": "A        RC=0012 4 spool files"
+    "Class": "A        RC=0012 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@USS2",
     "JobId": "JOB06310",
     "Owner": "Z33792",
     "Status": "OUTPUT",
-    "Class": "A        RC=0127 4 spool files"
+    "Class": "A        RC=0127 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@USS2",
     "JobId": "JOB06309",
     "Owner": "Z33792",
     "Status": "OUTPUT",
-    "Class": "A        RC=0127 4 spool files"
+    "Class": "A        RC=0127 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "NSPECT5",
     "JobId": "JOB06308",
     "Owner": "Z08115",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 5 spool files"
+    "Class": "A        RC=0000 5 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@RACF1",
     "JobId": "JOB06306",
     "Owner": "Z32319",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JES2JOB1",
     "JobId": "JOB06304",
     "Owner": "Z33859",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 3 spool files"
+    "Class": "A        RC=0000 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JES2JOB1",
     "JobId": "JOB06303",
     "Owner": "Z33859",
     "Status": "OUTPUT",
-    "Class": "A        RC=0020 3 spool files"
+    "Class": "A        RC=0020 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCLSETUP",
     "JobId": "JOB06300",
     "Owner": "Z33935",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 3 spool files"
+    "Class": "A        RC=0000 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JES2JOB1",
     "JobId": "JOB06299",
     "Owner": "Z33859",
     "Status": "OUTPUT",
-    "Class": "A        RC=0020 3 spool files"
+    "Class": "A        RC=0020 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@USS2",
     "JobId": "JOB06298",
     "Owner": "Z33792",
     "Status": "OUTPUT",
-    "Class": "A        RC=0127 4 spool files"
+    "Class": "A        RC=0127 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "CBLJSONJ",
     "JobId": "JOB06296",
     "Owner": "Z32883",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 5 spool files"
+    "Class": "A        RC=0000 5 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@USS",
     "JobId": "JOB06295",
     "Owner": "Z33792",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "E378859C",
     "JobId": "JOB06284",
     "Owner": "Z08115",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@USS",
     "JobId": "JOB06278",
     "Owner": "Z33792",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@USS2",
     "JobId": "JOB06277",
     "Owner": "Z33792",
     "Status": "OUTPUT",
-    "Class": "A        RC=0127 4 spool files"
+    "Class": "A        RC=0127 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@JCL1",
     "JobId": "JOB06274",
     "Owner": "Z33935",
     "Status": "OUTPUT",
-    "Class": "A        RC=0127 4 spool files"
+    "Class": "A        RC=0127 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@USS2",
     "JobId": "JOB06272",
     "Owner": "Z33792",
     "Status": "OUTPUT",
-    "Class": "A        RC=0127 4 spool files"
+    "Class": "A        RC=0127 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "E378859C",
     "JobId": "JOB06271",
     "Owner": "Z08115",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06270",
     "Owner": "Z33935",
     "Status": "OUTPUT",
-    "Class": "A        ABEND=000 7 spool files"
+    "Class": "A        ABEND=000 7 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCLSETUP",
     "JobId": "JOB06269",
     "Owner": "Z33935",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 3 spool files"
+    "Class": "A        RC=0000 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCLSETUP",
     "JobId": "JOB06267",
     "Owner": "Z33935",
     "Status": "OUTPUT",
-    "Class": "A        (JCL error) 3 spool files"
+    "Class": "A        (JCL error) 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06265",
     "Owner": "Z33935",
     "Status": "OUTPUT",
-    "Class": "A        (JCL error) 6 spool files"
+    "Class": "A        (JCL error) 6 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "CBLJSONJ",
     "JobId": "JOB06262",
     "Owner": "Z32883",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 5 spool files"
+    "Class": "A        RC=0000 5 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06261",
     "Owner": "Z33935",
     "Status": "OUTPUT",
-    "Class": "A        ABEND=000 7 spool files"
+    "Class": "A        ABEND=000 7 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "REPRO2",
     "JobId": "JOB06260",
     "Owner": "Z33649",
     "Status": "OUTPUT",
-    "Class": "A        RC=0012 4 spool files"
+    "Class": "A        RC=0012 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JES2JOB1",
     "JobId": "JOB06259",
     "Owner": "Z33859",
     "Status": "OUTPUT",
-    "Class": "A        RC=0008 3 spool files"
+    "Class": "A        RC=0008 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06258",
     "Owner": "Z33935",
     "Status": "OUTPUT",
-    "Class": "A        ABEND=000 7 spool files"
+    "Class": "A        ABEND=000 7 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "REPRO2",
     "JobId": "JOB06257",
     "Owner": "Z33649",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "REPRO2",
     "JobId": "JOB06256",
     "Owner": "Z33649",
     "Status": "OUTPUT",
-    "Class": "A        RC=0012 4 spool files"
+    "Class": "A        RC=0012 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "CBLJSONJ",
     "JobId": "JOB06255",
     "Owner": "Z32883",
     "Status": "OUTPUT",
-    "Class": "A        (JCL error) 3 spool files"
+    "Class": "A        (JCL error) 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "CBLJSONJ",
     "JobId": "JOB06254",
     "Owner": "Z32883",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 5 spool files"
+    "Class": "A        RC=0000 5 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "REPRO2",
     "JobId": "JOB06252",
     "Owner": "Z33649",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@ACLI",
     "JobId": "JOB06251",
     "Owner": "Z33859",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "REPRO2",
     "JobId": "JOB06250",
     "Owner": "Z33649",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "REPRO2",
     "JobId": "JOB06249",
     "Owner": "Z33649",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL3",
     "JobId": "JOB06248",
     "Owner": "Z33935",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 3 spool files"
+    "Class": "A        RC=0000 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL3",
     "JobId": "JOB06247",
     "Owner": "Z33935",
     "Status": "OUTPUT",
-    "Class": "A        (JCL error) 3 spool files"
+    "Class": "A        (JCL error) 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "REPRO2",
     "JobId": "JOB06246",
     "Owner": "Z33649",
     "Status": "OUTPUT",
-    "Class": "A        RC=0012 4 spool files"
+    "Class": "A        RC=0012 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL3",
     "JobId": "JOB06244",
     "Owner": "Z33935",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 3 spool files"
+    "Class": "A        RC=0000 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL3",
     "JobId": "JOB06243",
     "Owner": "Z33935",
     "Status": "OUTPUT",
-    "Class": "A        (JCL error) 3 spool files"
+    "Class": "A        (JCL error) 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@ACLI",
     "JobId": "JOB06242",
     "Owner": "Z33859",
     "Status": "OUTPUT",
-    "Class": "A        RC=0127 4 spool files"
+    "Class": "A        RC=0127 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL3",
     "JobId": "JOB06241",
     "Owner": "Z33935",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 3 spool files"
+    "Class": "A        RC=0000 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@JCL1",
     "JobId": "JOB06238",
     "Owner": "Z34020",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06236",
     "Owner": "Z34020",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 7 spool files"
+    "Class": "A        RC=0000 7 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06235",
     "Owner": "Z33935",
     "Status": "OUTPUT",
-    "Class": "A        ABEND=000 7 spool files"
+    "Class": "A        ABEND=000 7 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06233",
     "Owner": "Z34020",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 7 spool files"
+    "Class": "A        RC=0000 7 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@JCL1",
     "JobId": "JOB06230",
     "Owner": "Z34020",
     "Status": "OUTPUT",
-    "Class": "A        RC=0127 4 spool files"
+    "Class": "A        RC=0127 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL3",
     "JobId": "JOB06229",
     "Owner": "Z34020",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 3 spool files"
+    "Class": "A        RC=0000 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "REPRO2",
     "JobId": "JOB06226",
     "Owner": "Z33859",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL3",
     "JobId": "JOB06225",
     "Owner": "Z34020",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 3 spool files"
+    "Class": "A        RC=0000 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06224",
     "Owner": "Z33935",
     "Status": "OUTPUT",
-    "Class": "A        ABEND=000 7 spool files"
+    "Class": "A        ABEND=000 7 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL3",
     "JobId": "JOB06223",
     "Owner": "Z34020",
     "Status": "OUTPUT",
-    "Class": "A        (JCL error) 3 spool files"
+    "Class": "A        (JCL error) 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "REPRO2",
     "JobId": "JOB06221",
     "Owner": "Z33649",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL3",
     "JobId": "JOB06220",
     "Owner": "Z34020",
     "Status": "OUTPUT",
-    "Class": "A        (JCL error) 3 spool files"
+    "Class": "A        (JCL error) 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "REPRO2",
     "JobId": "JOB06219",
     "Owner": "Z33859",
     "Status": "OUTPUT",
-    "Class": "A        RC=0012 4 spool files"
+    "Class": "A        RC=0012 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06217",
     "Owner": "Z33935",
     "Status": "OUTPUT",
-    "Class": "A        ABEND=000 7 spool files"
+    "Class": "A        ABEND=000 7 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL3",
     "JobId": "JOB06216",
     "Owner": "Z34020",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 3 spool files"
+    "Class": "A        RC=0000 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06215",
     "Owner": "Z34020",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 7 spool files"
+    "Class": "A        RC=0000 7 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06214",
     "Owner": "Z34020",
     "Status": "OUTPUT",
-    "Class": "A        RC=0004 7 spool files"
+    "Class": "A        RC=0004 7 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06213",
     "Owner": "Z34020",
     "Status": "OUTPUT",
-    "Class": "A        ABEND=000 7 spool files"
+    "Class": "A        ABEND=000 7 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06212",
     "Owner": "Z34020",
     "Status": "OUTPUT",
-    "Class": "A        ABEND=000 7 spool files"
+    "Class": "A        ABEND=000 7 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06211",
     "Owner": "Z34020",
     "Status": "OUTPUT",
-    "Class": "A        ABEND=000 7 spool files"
+    "Class": "A        ABEND=000 7 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "REPRO2",
     "JobId": "JOB06210",
     "Owner": "Z33859",
     "Status": "OUTPUT",
-    "Class": "A        RC=0012 4 spool files"
+    "Class": "A        RC=0012 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "PRINT3",
     "JobId": "JOB06209",
     "Owner": "Z33859",
     "Status": "OUTPUT",
-    "Class": "A        (JCL error) 3 spool files"
+    "Class": "A        (JCL error) 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "PRINT3",
     "JobId": "JOB06208",
     "Owner": "Z33859",
     "Status": "OUTPUT",
-    "Class": "A        (JCL error) 3 spool files"
+    "Class": "A        (JCL error) 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06207",
     "Owner": "Z34020",
     "Status": "OUTPUT",
-    "Class": "A        ABEND=000 7 spool files"
+    "Class": "A        ABEND=000 7 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06206",
     "Owner": "Z33935",
     "Status": "OUTPUT",
-    "Class": "A        ABEND=000 7 spool files"
+    "Class": "A        ABEND=000 7 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06205",
     "Owner": "Z33935",
     "Status": "OUTPUT",
-    "Class": "A        ABEND=000 7 spool files"
+    "Class": "A        ABEND=000 7 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCLSETUP",
     "JobId": "JOB06204",
     "Owner": "Z34020",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 3 spool files"
+    "Class": "A        RC=0000 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "PRINT3",
     "JobId": "JOB06202",
     "Owner": "Z33859",
     "Status": "OUTPUT",
-    "Class": "A        (JCL error) 3 spool files"
+    "Class": "A        (JCL error) 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCLSETUP",
     "JobId": "JOB06201",
     "Owner": "Z33935",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 3 spool files"
+    "Class": "A        RC=0000 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@FILES1",
     "JobId": "JOB06199",
     "Owner": "Z34020",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@AANS2",
     "JobId": "JOB06198",
     "Owner": "Z32656",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "CBLJSONJ",
     "JobId": "JOB06197",
     "Owner": "Z05127",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 5 spool files"
+    "Class": "A        RC=0000 5 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "CBLJSONJ",
     "JobId": "JOB06193",
     "Owner": "Z05127",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 5 spool files"
+    "Class": "A        RC=0000 5 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "PDSBUILD",
     "JobId": "JOB06190",
     "Owner": "Z34020",
     "Status": "OUTPUT",
-    "Class": "A        RC=0008 5 spool files"
+    "Class": "A        RC=0008 5 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06189",
     "Owner": "Z33450",
     "Status": "OUTPUT",
-    "Class": "A        ABEND=000 7 spool files"
+    "Class": "A        ABEND=000 7 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@AANS2",
     "JobId": "JOB06188",
     "Owner": "Z32656",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06187",
     "Owner": "Z33450",
     "Status": "OUTPUT",
-    "Class": "A        ABEND=000 7 spool files"
+    "Class": "A        ABEND=000 7 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@VSC1",
     "JobId": "JOB06185",
     "Owner": "Z34020",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "ANOTHER",
     "JobId": "JOB06184",
     "Owner": "Z33500",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "HELLO",
     "JobId": "JOB06183",
     "Owner": "Z33500",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "HELLO",
     "JobId": "JOB06181",
     "Owner": "Z33500",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "HELLO",
     "JobId": "JOB06180",
     "Owner": "Z33500",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@JCL1",
     "JobId": "JOB06176",
     "Owner": "Z33450",
     "Status": "OUTPUT",
-    "Class": "A        RC=0127 4 spool files"
+    "Class": "A        RC=0127 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "HELLO",
     "JobId": "JOB06175",
     "Owner": "Z33500",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@JCL1",
     "JobId": "JOB06173",
     "Owner": "Z33450",
     "Status": "OUTPUT",
-    "Class": "A        RC=0127 4 spool files"
+    "Class": "A        RC=0127 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@AUTO",
     "JobId": "JOB06161",
     "Owner": "Z33873",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "CBLJSONJ",
     "JobId": "JOB06160",
     "Owner": "Z05127",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 5 spool files"
+    "Class": "A        RC=0000 5 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "CBLJSONJ",
     "JobId": "JOB06159",
     "Owner": "Z05127",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 5 spool files"
+    "Class": "A        RC=0000 5 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "CBLJSONJ",
     "JobId": "JOB06156",
     "Owner": "Z05127",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 5 spool files"
+    "Class": "A        RC=0000 5 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "CBLJSONJ",
     "JobId": "JOB06152",
     "Owner": "Z05127",
     "Status": "OUTPUT",
-    "Class": "A        RC=0008 4 spool files"
+    "Class": "A        RC=0008 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@SQL1",
     "JobId": "JOB06143",
     "Owner": "Z31525",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "CBLJSONJ",
     "JobId": "JOB06140",
     "Owner": "Z05127",
     "Status": "OUTPUT",
-    "Class": "A        RC=0008 4 spool files"
+    "Class": "A        RC=0008 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@SQL1",
     "JobId": "JOB06138",
     "Owner": "Z31525",
     "Status": "OUTPUT",
-    "Class": "A        RC=0127 4 spool files"
+    "Class": "A        RC=0127 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@REXX1",
     "JobId": "JOB06134",
     "Owner": "Z33997",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@USS",
     "JobId": "JOB06132",
     "Owner": "Z34008",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@RACF1",
     "JobId": "JOB06129",
     "Owner": "Z32921",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@USS2",
     "JobId": "JOB06119",
     "Owner": "Z31525",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@APDS2",
     "JobId": "JOB06118",
     "Owner": "Z33608",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "MERGSORT",
     "JobId": "JOB06117",
     "Owner": "Z33608",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@USS2",
     "JobId": "JOB06116",
     "Owner": "Z31525",
     "Status": "OUTPUT",
-    "Class": "A        RC=0127 4 spool files"
+    "Class": "A        RC=0127 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@APDS1",
     "JobId": "JOB06104",
     "Owner": "Z33608",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "PDS1CCAT",
     "JobId": "JOB06102",
     "Owner": "Z33608",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "CBLJSONJ",
     "JobId": "JOB06099",
     "Owner": "Z05127",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 5 spool files"
+    "Class": "A        RC=0000 5 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCLSETUP",
     "JobId": "JOB06080",
     "Owner": "Z33883",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 3 spool files"
+    "Class": "A        RC=0000 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCLRESET",
     "JobId": "JOB06079",
     "Owner": "Z33883",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL3",
     "JobId": "JOB06073",
     "Owner": "Z33450",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 3 spool files"
+    "Class": "A        RC=0000 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@ASM1",
     "JobId": "JOB06065",
     "Owner": "Z14836",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@JCL1",
     "JobId": "JOB06061",
     "Owner": "Z33995",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@CODE",
     "JobId": "JOB06057",
     "Owner": "Z33997",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL3",
     "JobId": "JOB06053",
     "Owner": "Z33995",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 3 spool files"
+    "Class": "A        RC=0000 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@JCL1",
     "JobId": "JOB06051",
     "Owner": "Z34008",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "PLICNT",
     "JobId": "JOB06047",
     "Owner": "Z32319",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 6 spool files"
+    "Class": "A        RC=0000 6 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCLSETUP",
     "JobId": "JOB06041",
     "Owner": "Z33883",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 3 spool files"
+    "Class": "A        RC=0000 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@REXX1",
     "JobId": "JOB06038",
     "Owner": "Z33873",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL3",
     "JobId": "JOB06036",
     "Owner": "Z34008",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 3 spool files"
+    "Class": "A        RC=0000 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "ASMPGM",
     "JobId": "JOB06035",
     "Owner": "Z32792",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 5 spool files"
+    "Class": "A        RC=0000 5 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL3",
     "JobId": "JOB06034",
     "Owner": "Z34008",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 3 spool files"
+    "Class": "A        RC=0000 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@FILES1",
     "JobId": "JOB06028",
     "Owner": "Z33883",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL3",
     "JobId": "JOB06027",
     "Owner": "Z34008",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 3 spool files"
+    "Class": "A        RC=0000 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL3",
     "JobId": "JOB06019",
     "Owner": "Z33995",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 3 spool files"
+    "Class": "A        RC=0000 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCLSETUP",
     "JobId": "JOB06018",
     "Owner": "Z32131",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 3 spool files"
+    "Class": "A        RC=0000 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCLRESET",
     "JobId": "JOB06017",
     "Owner": "Z32131",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL3",
     "JobId": "JOB06015",
     "Owner": "Z34008",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 3 spool files"
+    "Class": "A        RC=0000 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@GO1",
     "JobId": "JOB06010",
     "Owner": "Z32319",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@FILES1",
     "JobId": "JOB06009",
     "Owner": "Z33883",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL2",
     "JobId": "JOB06007",
     "Owner": "Z33995",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 7 spool files"
+    "Class": "A        RC=0000 7 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "NSPECT3",
     "JobId": "JOB06003",
     "Owner": "Z08115",
     "Status": "OUTPUT",
-    "Class": "A        RC=0008 4 spool files"
+    "Class": "A        RC=0008 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@VSC1",
     "JobId": "JOB06001",
     "Owner": "Z32861",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "Z08593B",
     "JobId": "JOB06000",
     "Owner": "Z08593",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 5 spool files"
+    "Class": "A        RC=0000 5 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@AUTO",
     "JobId": "JOB05999",
     "Owner": "Z33984",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@AUTO",
     "JobId": "JOB05990",
     "Owner": "Z33984",
     "Status": "OUTPUT",
-    "Class": "A        RC=0127 4 spool files"
+    "Class": "A        RC=0127 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "Z08593A",
     "JobId": "JOB05989",
     "Owner": "Z08593",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 5 spool files"
+    "Class": "A        RC=0000 5 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@USS2",
     "JobId": "JOB05984",
     "Owner": "Z33489",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "E378859C",
     "JobId": "JOB05982",
     "Owner": "Z08115",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@ACLI",
     "JobId": "JOB05978",
     "Owner": "Z32586",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@AUTO",
     "JobId": "JOB05977",
     "Owner": "Z33234",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL2",
     "JobId": "JOB05972",
     "Owner": "Z34008",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 7 spool files"
+    "Class": "A        RC=0000 7 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@JCL1",
     "JobId": "JOB05966",
     "Owner": "Z04518",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL3",
     "JobId": "JOB05959",
     "Owner": "Z04518",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 3 spool files"
+    "Class": "A        RC=0000 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@APDS2",
     "JobId": "JOB05958",
     "Owner": "Z33489",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "REPRO2",
     "JobId": "JOB05957",
     "Owner": "Z32586",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@CODE",
     "JobId": "JOB05955",
     "Owner": "Z33873",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@USS",
     "JobId": "JOB05954",
     "Owner": "Z33997",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL2",
     "JobId": "JOB05953",
     "Owner": "Z04518",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 7 spool files"
+    "Class": "A        RC=0000 7 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@CODE",
     "JobId": "JOB05947",
     "Owner": "Z33873",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@REXX1",
     "JobId": "JOB05948",
     "Owner": "Z33984",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "REPRO2",
     "JobId": "JOB05942",
     "Owner": "Z32586",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@FILES1",
     "JobId": "JOB05941",
     "Owner": "Z34015",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@APDS2",
     "JobId": "JOB05940",
     "Owner": "Z33489",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "MERGSORT",
     "JobId": "JOB05934",
     "Owner": "Z33489",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCLSETUP",
     "JobId": "JOB05931",
     "Owner": "Z33995",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 3 spool files"
+    "Class": "A        RC=0000 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCLSETUP",
     "JobId": "JOB05929",
     "Owner": "Z33450",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 3 spool files"
+    "Class": "A        RC=0000 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "REPRO2",
     "JobId": "JOB05927",
     "Owner": "Z32586",
     "Status": "OUTPUT",
-    "Class": "A        RC=0012 4 spool files"
+    "Class": "A        RC=0012 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@REXX1",
     "JobId": "JOB05926",
     "Owner": "Z33384",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "REPRO2",
     "JobId": "JOB05925",
     "Owner": "Z32586",
     "Status": "OUTPUT",
-    "Class": "A        RC=0012 4 spool files"
+    "Class": "A        RC=0012 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@APDS1",
     "JobId": "JOB05924",
     "Owner": "Z33489",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "PDS1CCAT",
     "JobId": "JOB05916",
     "Owner": "Z33489",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@VSC1",
     "JobId": "JOB05914",
     "Owner": "Z34043",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "PDSBUILD",
     "JobId": "JOB05910",
     "Owner": "Z34015",
     "Status": "OUTPUT",
-    "Class": "A        RC=0008 5 spool files"
+    "Class": "A        RC=0008 5 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@APDS1",
     "JobId": "JOB05909",
     "Owner": "Z15237",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@SQL1",
     "JobId": "JOB05908",
     "Owner": "Z33415",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@FILES1",
     "JobId": "JOB05907",
     "Owner": "Z33995",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "PDS1CCAT",
     "JobId": "JOB05905",
     "Owner": "Z15237",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@APDS2",
     "JobId": "JOB05886",
     "Owner": "Z33328",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@JCL2",
     "JobId": "JOB05885",
     "Owner": "Z33489",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCLSETUP",
     "JobId": "JOB05884",
     "Owner": "Z04518",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 3 spool files"
+    "Class": "A        RC=0000 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JES2JOB1",
     "JobId": "JOB05881",
     "Owner": "Z33489",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 3 spool files"
+    "Class": "A        RC=0000 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "MERGSORT",
     "JobId": "JOB05879",
     "Owner": "Z33328",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "PDSBUILD",
     "JobId": "JOB05876",
     "Owner": "Z33995",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 5 spool files"
+    "Class": "A        RC=0000 5 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JES2JOB1",
     "JobId": "JOB05874",
     "Owner": "Z33489",
     "Status": "OUTPUT",
-    "Class": "A        RC=0008 3 spool files"
+    "Class": "A        RC=0008 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCLSETUP",
     "JobId": "JOB05868",
     "Owner": "Z04518",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 3 spool files"
+    "Class": "A        RC=0000 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCLRESET",
     "JobId": "JOB05867",
     "Owner": "Z04518",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCLSETUP",
     "JobId": "JOB05863",
     "Owner": "Z04518",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 3 spool files"
+    "Class": "A        RC=0000 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCLRESET",
     "JobId": "JOB05862",
     "Owner": "Z04518",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@FILES1",
     "JobId": "JOB05858",
     "Owner": "Z04518",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCLSETUP",
     "JobId": "JOB05857",
     "Owner": "Z34008",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 3 spool files"
+    "Class": "A        RC=0000 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@USS2",
     "JobId": "JOB05851",
     "Owner": "Z33328",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "PDSBUILD",
     "JobId": "JOB05847",
     "Owner": "Z04518",
     "Status": "OUTPUT",
-    "Class": "A        RC=0008 5 spool files"
+    "Class": "A        RC=0008 5 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@ACBLH",
     "JobId": "JOB05845",
     "Owner": "Z32319",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@JCL1",
     "JobId": "JOB05843",
     "Owner": "Z33997",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "CBLJSONJ",
     "JobId": "JOB05840",
     "Owner": "Z32319",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 5 spool files"
+    "Class": "A        RC=0000 5 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL3",
     "JobId": "JOB05839",
     "Owner": "Z33997",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 3 spool files"
+    "Class": "A        RC=0000 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@SQL1",
     "JobId": "JOB05829",
     "Owner": "Z15237",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@CODE",
     "JobId": "JOB05827",
     "Owner": "Z33984",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@SQL1",
     "JobId": "JOB05823",
     "Owner": "Z29921",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@AUTO",
     "JobId": "JOB05821",
     "Owner": "Z33489",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL3",
     "JobId": "JOB05811",
     "Owner": "Z33997",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 3 spool files"
+    "Class": "A        RC=0000 3 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@USS",
     "JobId": "JOB05799",
     "Owner": "Z33873",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@FILES1",
     "JobId": "JOB05795",
     "Owner": "Z34008",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "JCL2",
     "JobId": "JOB05793",
     "Owner": "Z33997",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 7 spool files"
+    "Class": "A        RC=0000 7 spool files",
+    "SpoolFiles": 0
   },
   {
     "Name": "@@USS",
     "JobId": "JOB05779",
     "Owner": "Z33984",
     "Status": "OUTPUT",
-    "Class": "A        RC=0000 4 spool files"
+    "Class": "A        RC=0000 4 spool files",
+    "SpoolFiles": 0
   }
 ]

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -117,14 +117,17 @@ func RemoveNewLine(name string) string {
 	return trims.ReplaceAllString(name, "")
 }
 
-var regexLastWord = regexp.MustCompile(`\s(\w+)$`)
-
+// LastWord returns the last whitespace-delimited token of str, or "" when str has
+// no non-space content. The token may contain any non-space characters, so it
+// preserves values a `\w+` match would truncate or drop entirely: dotted dataset
+// names (MY.MODEL.DSN), '*'/'?' wildcards, parenthesized codepage pairs, and
+// hyphenated codepage names (IBM-1047).
 func LastWord(str string) string {
-	matches := regexLastWord.FindStringSubmatch(str)
-	if len(matches) == 2 {
-		return matches[1]
+	fields := strings.Fields(str)
+	if len(fields) == 0 {
+		return ""
 	}
-	return ""
+	return fields[len(fields)-1]
 }
 
 func LastWordToInt(str string) (int, error) {

--- a/jes.go
+++ b/jes.go
@@ -153,33 +153,7 @@ func (s *FTPSession) SubmitJesGetByDSN(jcl string) (*JobResult, error) {
 	job.DisplayName = res[1]
 
 	/* analyze for job abending or IEF errors */
-
-	errDetails := make([]string, 0)
-	var errType error
-	lines := strings.Split(jobOutput.String(), "\n")
-	/* analyze if job has abend errors */
-	for _, line := range lines {
-		for key := range abaMessages {
-			if strings.Contains(line, key) {
-				errDetails = append(errDetails, strings.TrimSpace(line))
-				errType = ErrAba
-			}
-		}
-	}
-
-	/* analyze if job has errors */
-	for _, line := range lines {
-		for key := range iefMessages {
-			if strings.Contains(line, key) {
-				errDetails = append(errDetails, strings.TrimSpace(line))
-				if errors.Is(errType, ErrAba) || errors.Is(errType, ErrIEFAndABA) {
-					errType = ErrIEFAndABA
-				} else {
-					errType = ErrIEF
-				}
-			}
-		}
-	}
+	errType, errDetails := classifyJesOutput(jobOutput.String())
 
 	/* get job return code from response */
 	res = jesJobDoneRcRegexp.FindStringSubmatch(jobOutput.String())
@@ -196,6 +170,39 @@ func (s *FTPSession) SubmitJesGetByDSN(jcl string) (*JobResult, error) {
 		return job, fmt.Errorf("failed to parse job return code %q: %w", res[2], err)
 	}
 	return job, nil
+}
+
+// classifyJesOutput scans JES job output for ABEND (ABAxxx) and allocation/JCL
+// (IEFxxx) message identifiers, returning the matching sentinel — ErrAba, ErrIEF,
+// or ErrIEFAndABA when both kinds are present — together with the matched, trimmed
+// lines. It returns (nil, nil) when no such message is found. The sentinel is
+// returned (not wrapped) so callers can match it with errors.Is once it is
+// wrapped with %w at the call site.
+func classifyJesOutput(output string) (errType error, details []string) {
+	lines := strings.Split(output, "\n")
+	/* analyze if job has abend errors */
+	for _, line := range lines {
+		for key := range abaMessages {
+			if strings.Contains(line, key) {
+				details = append(details, strings.TrimSpace(line))
+				errType = ErrAba
+			}
+		}
+	}
+	/* analyze if job has IEF (allocation/JCL) errors */
+	for _, line := range lines {
+		for key := range iefMessages {
+			if strings.Contains(line, key) {
+				details = append(details, strings.TrimSpace(line))
+				if errors.Is(errType, ErrAba) || errors.Is(errType, ErrIEFAndABA) {
+					errType = ErrIEFAndABA
+				} else {
+					errType = ErrIEF
+				}
+			}
+		}
+	}
+	return errType, details
 }
 
 // Generate a unique job name based on timestamp and random number

--- a/jes.go
+++ b/jes.go
@@ -153,7 +153,7 @@ func (s *FTPSession) SubmitJesGetByDSN(jcl string) (*JobResult, error) {
 	job.DisplayName = res[1]
 
 	/* analyze for job abending or IEF errors */
-	errType, errDetails := classifyJesOutput(jobOutput.String())
+	errDetails, errType := classifyJesOutput(jobOutput.String())
 
 	/* get job return code from response */
 	res = jesJobDoneRcRegexp.FindStringSubmatch(jobOutput.String())
@@ -173,12 +173,12 @@ func (s *FTPSession) SubmitJesGetByDSN(jcl string) (*JobResult, error) {
 }
 
 // classifyJesOutput scans JES job output for ABEND (ABAxxx) and allocation/JCL
-// (IEFxxx) message identifiers, returning the matching sentinel — ErrAba, ErrIEF,
-// or ErrIEFAndABA when both kinds are present — together with the matched, trimmed
-// lines. It returns (nil, nil) when no such message is found. The sentinel is
+// (IEFxxx) message identifiers, returning the matched, trimmed lines together with
+// the matching sentinel — ErrAba, ErrIEF, or ErrIEFAndABA when both kinds are
+// present. It returns (nil, nil) when no such message is found. The sentinel is
 // returned (not wrapped) so callers can match it with errors.Is once it is
 // wrapped with %w at the call site.
-func classifyJesOutput(output string) (errType error, details []string) {
+func classifyJesOutput(output string) (details []string, errType error) {
 	lines := strings.Split(output, "\n")
 	/* analyze if job has abend errors */
 	for _, line := range lines {
@@ -202,7 +202,7 @@ func classifyJesOutput(output string) (errType error, details []string) {
 			}
 		}
 	}
-	return errType, details
+	return details, errType
 }
 
 // Generate a unique job name based on timestamp and random number
@@ -286,15 +286,21 @@ func WithJesPutGetTimeOut(seconds int) JesSpec {
 	})
 }
 
-// WithJesJobPattern changes the search pattern for job-id in the response message
-// default pattern is `(JOB\d{5})`
+// WithJesJobPattern changes the search pattern for the job-id in the response
+// message. The default pattern is `(JOB\d{5})`. The pattern must contain exactly
+// one capturing group — the job-id is read from submatch[1] — so a pattern with
+// none or more than one group is rejected with an error rather than silently
+// breaking job-id extraction.
 func WithJesJobPattern(pattern string) JesSpec {
 	return JesOptionFunc(func(s *FTPSession) error {
-		var err error
-		s.jobPrefix, err = regexp.Compile(pattern)
+		re, err := regexp.Compile(pattern)
 		if err != nil {
 			return err
 		}
+		if n := re.NumSubexp(); n != 1 {
+			return fmt.Errorf("zftp: jes job pattern %q must have exactly one capturing group, has %d", pattern, n)
+		}
+		s.jobPrefix = re
 		return nil
 	})
 }

--- a/jes_classify_test.go
+++ b/jes_classify_test.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package zftp
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestClassifyJesOutput verifies the JES output classifier — the producer of the
+// JES sentinels — returns each sentinel errors.Is-matchably: an ABEND (ABAxxx)
+// message yields ErrAba, an allocation/JCL (IEFxxx) message yields ErrIEF, both
+// together yield ErrIEFAndABA, and clean output yields no error.
+func TestClassifyJesOutput(t *testing.T) {
+	if errType, _ := classifyJesOutput("preamble\nABA001I task abended\ntail"); !errors.Is(errType, ErrAba) {
+		t.Errorf("ABA-only: errType = %v, want ErrAba", errType)
+	}
+	if errType, _ := classifyJesOutput("IEF001I write to message file failed"); !errors.Is(errType, ErrIEF) {
+		t.Errorf("IEF-only: errType = %v, want ErrIEF", errType)
+	}
+	if errType, details := classifyJesOutput("ABA001I boom\nIEF001I oops"); !errors.Is(errType, ErrIEFAndABA) {
+		t.Errorf("both: errType = %v (details %v), want ErrIEFAndABA", errType, details)
+	}
+	if errType, details := classifyJesOutput("all good\njob completed cleanly"); errType != nil || len(details) != 0 {
+		t.Errorf("clean: errType=%v details=%v, want nil/empty", errType, details)
+	}
+}

--- a/jes_classify_test.go
+++ b/jes_classify_test.go
@@ -12,16 +12,16 @@ import (
 // message yields ErrAba, an allocation/JCL (IEFxxx) message yields ErrIEF, both
 // together yield ErrIEFAndABA, and clean output yields no error.
 func TestClassifyJesOutput(t *testing.T) {
-	if errType, _ := classifyJesOutput("preamble\nABA001I task abended\ntail"); !errors.Is(errType, ErrAba) {
+	if _, errType := classifyJesOutput("preamble\nABA001I task abended\ntail"); !errors.Is(errType, ErrAba) {
 		t.Errorf("ABA-only: errType = %v, want ErrAba", errType)
 	}
-	if errType, _ := classifyJesOutput("IEF001I write to message file failed"); !errors.Is(errType, ErrIEF) {
+	if _, errType := classifyJesOutput("IEF001I write to message file failed"); !errors.Is(errType, ErrIEF) {
 		t.Errorf("IEF-only: errType = %v, want ErrIEF", errType)
 	}
-	if errType, details := classifyJesOutput("ABA001I boom\nIEF001I oops"); !errors.Is(errType, ErrIEFAndABA) {
+	if details, errType := classifyJesOutput("ABA001I boom\nIEF001I oops"); !errors.Is(errType, ErrIEFAndABA) {
 		t.Errorf("both: errType = %v (details %v), want ErrIEFAndABA", errType, details)
 	}
-	if errType, details := classifyJesOutput("all good\njob completed cleanly"); errType != nil || len(details) != 0 {
+	if details, errType := classifyJesOutput("all good\njob completed cleanly"); errType != nil || len(details) != 0 {
 		t.Errorf("clean: errType=%v details=%v, want nil/empty", errType, details)
 	}
 }

--- a/jes_constants.go
+++ b/jes_constants.go
@@ -2,11 +2,21 @@
 
 package zftp
 
-import "fmt"
+import "errors"
 
-var ErrIEF = fmt.Errorf("IEF error")
-var ErrAba = fmt.Errorf("ABA error")
-var ErrIEFAndABA = fmt.Errorf("IEF/ABA error")
+// Sentinels reported by SubmitJesGetByDSN when scanning a job's spool output for
+// system messages. They are wrapped with %w at the call site, so callers match
+// them with errors.Is, e.g. errors.Is(err, zftp.ErrAba).
+var (
+	// ErrIEF indicates the job output contained one or more IEFxxx allocation or
+	// JCL messages (see iefMessages).
+	ErrIEF = errors.New("IEF error")
+	// ErrAba indicates the job output contained one or more ABAxxx abend messages
+	// (see abaMessages).
+	ErrAba = errors.New("ABA error")
+	// ErrIEFAndABA indicates the job output contained both IEF and ABA messages.
+	ErrIEFAndABA = errors.New("IEF/ABA error")
+)
 
 var iefMessages = map[string]string{
 	"IEF001I": "ERROR ON WRITE TO SYSTEM MESSAGE FILE",

--- a/jes_pattern_test.go
+++ b/jes_pattern_test.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package zftp_test
+
+import (
+	"testing"
+
+	zftp "gopkg.in/ro-ag/zftp.v2"
+)
+
+// TestWithJesJobPattern_GroupValidation verifies WithJesJobPattern accepts a
+// pattern with exactly one capturing group (the job-id) and rejects patterns with
+// none or more than one, as well as patterns that do not compile. The job-id is
+// read from submatch[1], so a wrong group count would silently break extraction.
+func TestWithJesJobPattern_GroupValidation(t *testing.T) {
+	s, _ := dialMock(t)
+
+	if err := zftp.WithJesJobPattern(`(JOB\d{5})`).Apply(s); err != nil {
+		t.Errorf("one capturing group: unexpected error: %v", err)
+	}
+	if err := zftp.WithJesJobPattern(`JOB\d{5}`).Apply(s); err == nil {
+		t.Error("zero capturing groups: want error")
+	}
+	if err := zftp.WithJesJobPattern(`(JOB)(\d{5})`).Apply(s); err == nil {
+		t.Error("two capturing groups: want error")
+	}
+	if err := zftp.WithJesJobPattern(`(`).Apply(s); err == nil {
+		t.Error("invalid regexp: want error")
+	}
+}

--- a/status_get.go
+++ b/status_get.go
@@ -446,12 +446,15 @@ func (s *ServerStatus) RetPD() (int, error) {
 	return utils.LastWordToInt(resp)
 }
 
-func (s *ServerStatus) SBDataConn() (int, error) {
+// SBDataConn returns the single-byte data-connection codepage reported by the
+// server (e.g. IBM-1047). SBDATACONN is a codepage string, not an integer, so it
+// is returned as a string (mirroring MBDataConn).
+func (s *ServerStatus) SBDataConn() (string, error) {
 	resp, err := s.xstat("SBDataConn")
 	if err != nil {
-		return 0, err
+		return "", err
 	}
-	return utils.LastWordToInt(resp)
+	return utils.LastWord(resp), nil
 }
 
 func (s *ServerStatus) SBSendEol() (string, error) {
@@ -578,12 +581,20 @@ func (s *ServerStatus) UCSTrunc() (string, error) {
 	return utils.LastWord(resp), nil
 }
 
+// UMask returns the file-mode creation mask reported by the server. z/OS reports
+// UMASK in octal, so the value is parsed base 8 and returned as its integer value
+// (e.g. "022" -> 18).
 func (s *ServerStatus) UMask() (int, error) {
 	resp, err := s.xstat("UMask")
 	if err != nil {
 		return 0, err
 	}
-	return utils.LastWordToInt(resp)
+	w := utils.LastWord(resp)
+	n, err := strconv.ParseInt(w, 8, 0)
+	if err != nil {
+		return 0, fmt.Errorf("could not parse octal UMask %q: %w", w, err)
+	}
+	return int(n), nil
 }
 
 func (s *ServerStatus) UnicodeFileSystemBOM() (string, error) {

--- a/status_test.go
+++ b/status_test.go
@@ -86,6 +86,77 @@ func TestStatusSetter_FileType(t *testing.T) {
 	}
 }
 
+// TestServerStatus_DCBDSN_DottedName verifies a fully-qualified, dotted model DSN
+// survives parsing. The old LastWord regex `\s(\w+)$` excluded '.', so a dotted
+// DCBDSN came back empty.
+func TestServerStatus_DCBDSN_DottedName(t *testing.T) {
+	s, srv := dialMock(t)
+	srv.Script("XSTA (DCBDSN",
+		"211-DCBDSN MY.MODEL.DSN",
+		"211 *** end of status ***")
+
+	got, err := s.StatusOf().DCBDSN()
+	if err != nil {
+		t.Fatalf("DCBDSN: %v", err)
+	}
+	if got != "MY.MODEL.DSN" {
+		t.Errorf("DCBDSN = %q, want MY.MODEL.DSN", got)
+	}
+}
+
+// TestServerStatus_UMask_Octal verifies UMask is parsed as octal: "022" is octal
+// for decimal 18. It was previously parsed as decimal (returning 22).
+func TestServerStatus_UMask_Octal(t *testing.T) {
+	s, srv := dialMock(t)
+	srv.Script("XSTA (UMask",
+		"211-UMask 022",
+		"211 *** end of status ***")
+
+	got, err := s.StatusOf().UMask()
+	if err != nil {
+		t.Fatalf("UMask: %v", err)
+	}
+	if got != 18 {
+		t.Errorf("UMask = %d, want 18 (octal 022)", got)
+	}
+}
+
+// TestServerStatus_SBDataConn_Codepage verifies SBDataConn returns the codepage
+// as a string. SBDATACONN is a codepage (e.g. IBM-1047), not an integer; the old
+// (int) signature could not represent it and the hyphenated token failed the
+// integer parse. The scripted reply is representative, not a captured LPAR reply.
+func TestServerStatus_SBDataConn_Codepage(t *testing.T) {
+	s, srv := dialMock(t)
+	srv.Script("XSTA (SBDataConn",
+		"211-SBDataConn IBM-1047",
+		"211 *** end of status ***")
+
+	got, err := s.StatusOf().SBDataConn()
+	if err != nil {
+		t.Fatalf("SBDataConn: %v", err)
+	}
+	if got != "IBM-1047" {
+		t.Errorf("SBDataConn = %q, want IBM-1047", got)
+	}
+}
+
+// TestServerStatus_Unit_Sibling is a regression guard: a plain-token LastWord
+// sibling getter must keep returning its token after the LastWord change.
+func TestServerStatus_Unit_Sibling(t *testing.T) {
+	s, srv := dialMock(t)
+	srv.Script("XSTA (Unit",
+		"211-Unit SYSDA",
+		"211 *** end of status ***")
+
+	got, err := s.StatusOf().Unit()
+	if err != nil {
+		t.Fatalf("Unit: %v", err)
+	}
+	if got != "SYSDA" {
+		t.Errorf("Unit = %q, want SYSDA", got)
+	}
+}
+
 func TestTransferType_Concrete(t *testing.T) {
 	if !zftp.TypeAscii.IsAscii() || zftp.TypeAscii.IsBinary() {
 		t.Error("TypeAscii classification wrong")

--- a/transfer.go
+++ b/transfer.go
@@ -153,17 +153,34 @@ func (s *FTPSession) confirmData(child *childConnection) (string, error) {
 	return s.checkLast(CodeFileActionOK)
 }
 
+// restoreType puts the session back to a prior transfer type and is meant to be
+// deferred immediately after a successful SetType. It guards the error path: a
+// transfer failure must surface, so it never overwrites a non-nil *errp; it only
+// reports a restore failure when the transfer itself succeeded. When the session
+// was already torn down (e.g. a data-stream failure closed it), there is nothing
+// to restore and it returns without touching the control connection.
+func (s *FTPSession) restoreType(prev TransferType, errp *error) {
+	if s.IsClosed() {
+		return
+	}
+	if rerr := s.SetType(prev); rerr != nil && *errp == nil {
+		*errp = fmt.Errorf("error while setting back the transfer type: %w", rerr)
+	}
+}
+
 // StoreIO stores the contents of the reader to the remote file in the specified
 // mode and returns the number of bytes transferred.
 //
-// The original transfer type is restored to the previous value after the transfer,
-// supports ASCII and binary/Image transfers
-func (s *FTPSession) StoreIO(remote string, src io.Reader, t TransferType) (int64, string, error) {
+// The original transfer type is restored to the previous value after the transfer
+// (including when the transfer fails at the control level and the session stays
+// open); supports ASCII and binary/Image transfers.
+func (s *FTPSession) StoreIO(remote string, src io.Reader, t TransferType) (sz int64, msg string, err error) {
 
 	current := s.currentType()
-	if err := s.SetType(t); err != nil {
+	if err = s.SetType(t); err != nil {
 		return 0, "", err
 	}
+	defer s.restoreType(current, &err)
 
 	var format transfer.DataTransfer
 
@@ -173,60 +190,48 @@ func (s *FTPSession) StoreIO(remote string, src io.Reader, t TransferType) (int6
 		format = transfer.NewStore(src)
 	}
 
-	sz, msg, err := s.transfer(format, remote, 0)
-	if err != nil {
-		return sz, msg, err
-	}
-
-	if err = s.SetType(current); err != nil {
-		return sz, msg, fmt.Errorf("error while setting back the transfer type: %w", err)
-	}
-
+	sz, msg, err = s.transfer(format, remote, 0)
 	return sz, msg, err
 }
 
-// RetrieveIO retrieves the contents of the remote file and writes it to the writer
-// The transfer type is restored to the previous value after the transfer
-// supports ASCII and binary/Image transfers
-func (s *FTPSession) RetrieveIO(remote string, dest io.Writer, t TransferType) (int64, string, error) {
+// RetrieveIO retrieves the contents of the remote file and writes it to the writer.
+// The transfer type is restored to the previous value after the transfer (including
+// when the transfer fails at the control level and the session stays open);
+// supports ASCII and binary/Image transfers.
+func (s *FTPSession) RetrieveIO(remote string, dest io.Writer, t TransferType) (sz int64, msg string, err error) {
 	current := s.currentType()
 	if t.IsAscii() {
-		if err := s.SetStatusOf().SBSendEol(eol.System); err != nil {
+		if err = s.SetStatusOf().SBSendEol(eol.System); err != nil {
 			return 0, "", err
 		}
 	}
-	if err := s.SetType(t); err != nil {
+	if err = s.SetType(t); err != nil {
 		return 0, "", err
 	}
+	defer s.restoreType(current, &err)
 
-	sz, msg, err := s.transfer(transfer.NewRetrieve(dest), remote, 0)
-	if err != nil {
-		return sz, msg, err
-	}
-
-	if err = s.SetType(current); err != nil {
-		return sz, msg, fmt.Errorf("error while setting back the transfer type: %w", err)
-	}
-
+	sz, msg, err = s.transfer(transfer.NewRetrieve(dest), remote, 0)
 	return sz, msg, err
 }
 
 // StoreIOAt performs a store operation starting at the given offset on the remote file.
-// The transfer type is restored to the previous value after the transfer.
+// The transfer type is restored to the previous value after the transfer (including
+// when the transfer fails at the control level and the session stays open).
 //
 // Resume requires image/binary mode: a positive offset combined with TypeAscii
 // returns ErrAsciiResumeUnsupported before any I/O, because in ASCII mode the
 // server's EOL/codepage translation makes a byte offset corrupt the data.
-func (s *FTPSession) StoreIOAt(remote string, src io.Reader, t TransferType, offset int64) (int64, string, error) {
+func (s *FTPSession) StoreIOAt(remote string, src io.Reader, t TransferType, offset int64) (sz int64, msg string, err error) {
 
-	if err := guardResume(t, offset); err != nil {
+	if err = guardResume(t, offset); err != nil {
 		return 0, "", err
 	}
 
 	current := s.currentType()
-	if err := s.SetType(t); err != nil {
+	if err = s.SetType(t); err != nil {
 		return 0, "", err
 	}
+	defer s.restoreType(current, &err)
 
 	var format transfer.DataTransfer
 
@@ -236,46 +241,32 @@ func (s *FTPSession) StoreIOAt(remote string, src io.Reader, t TransferType, off
 		format = transfer.NewStore(src)
 	}
 
-	sz, msg, err := s.transfer(format, remote, offset)
-	if err != nil {
-		return sz, msg, err
-	}
-
-	if err = s.SetType(current); err != nil {
-		return sz, msg, fmt.Errorf("error while setting back the transfer type: %w", err)
-	}
-
+	sz, msg, err = s.transfer(format, remote, offset)
 	return sz, msg, err
 }
 
 // RetrieveIOAt performs a retrieve operation starting from the given offset of the remote file.
-// The transfer type is restored to the previous value after the transfer.
+// The transfer type is restored to the previous value after the transfer (including
+// when the transfer fails at the control level and the session stays open).
 //
 // Resume requires image/binary mode: a positive offset combined with TypeAscii
 // returns ErrAsciiResumeUnsupported before any I/O, because in ASCII mode the
 // server's EOL/codepage translation makes a byte offset corrupt the data.
-func (s *FTPSession) RetrieveIOAt(remote string, dest io.Writer, t TransferType, offset int64) (int64, string, error) {
-	if err := guardResume(t, offset); err != nil {
+func (s *FTPSession) RetrieveIOAt(remote string, dest io.Writer, t TransferType, offset int64) (sz int64, msg string, err error) {
+	if err = guardResume(t, offset); err != nil {
 		return 0, "", err
 	}
 	current := s.currentType()
 	if t.IsAscii() {
-		if err := s.SetStatusOf().SBSendEol(eol.System); err != nil {
+		if err = s.SetStatusOf().SBSendEol(eol.System); err != nil {
 			return 0, "", err
 		}
 	}
-	if err := s.SetType(t); err != nil {
+	if err = s.SetType(t); err != nil {
 		return 0, "", err
 	}
+	defer s.restoreType(current, &err)
 
-	sz, msg, err := s.transfer(transfer.NewRetrieve(dest), remote, offset)
-	if err != nil {
-		return sz, msg, err
-	}
-
-	if err = s.SetType(current); err != nil {
-		return sz, msg, fmt.Errorf("error while setting back the transfer type: %w", err)
-	}
-
+	sz, msg, err = s.transfer(transfer.NewRetrieve(dest), remote, offset)
 	return sz, msg, err
 }

--- a/transfer_mock_test.go
+++ b/transfer_mock_test.go
@@ -141,6 +141,76 @@ func TestStoreIOAt_AsciiOffsetRejected(t *testing.T) {
 	}
 }
 
+// TestRetrieveIO_RestoresTypeOnControlFailure verifies the transfer type is
+// restored even when the retrieve fails at the control level — RETR is rejected
+// with 550 before the data phase, so (unlike a data-stream failure) the session
+// stays open and must not be left on the wrong TYPE. The login default is TYPE I;
+// the ASCII retrieve issues TYPE A, and after the failed RETR a TYPE I must
+// follow to put the session back.
+func TestRetrieveIO_RestoresTypeOnControlFailure(t *testing.T) {
+	s, srv := dialMock(t)
+	srv.Script("RETR", "550 not found")
+
+	var buf bytes.Buffer
+	_, _, err := s.RetrieveIO("NO.SUCH.FILE", &buf, zftp.TypeAscii)
+	if err == nil {
+		t.Fatal("expected an error from the rejected RETR")
+	}
+
+	cmds := srv.Commands()
+	a := cmdIndex(cmds, "TYPE A")
+	if a < 0 {
+		t.Fatalf("expected a TYPE A for the ASCII retrieve; commands=%v", cmds)
+	}
+	if !hasCmd(cmds[a+1:], "TYPE I") {
+		t.Errorf("transfer type not restored to TYPE I after a failed retrieve; commands=%v", cmds)
+	}
+}
+
+// TestStoreIO_RestoresTypeOnControlFailure is the StoreIO counterpart: STOR is
+// rejected with 550 before the data phase (session stays open), and the ASCII
+// store's TYPE A must still be restored to the login default TYPE I.
+func TestStoreIO_RestoresTypeOnControlFailure(t *testing.T) {
+	s, srv := dialMock(t)
+	srv.Script("STOR", "550 access denied")
+
+	_, _, err := s.StoreIO("NO.SUCH.FILE", strings.NewReader("data"), zftp.TypeAscii)
+	if err == nil {
+		t.Fatal("expected an error from the rejected STOR")
+	}
+
+	cmds := srv.Commands()
+	a := cmdIndex(cmds, "TYPE A")
+	if a < 0 {
+		t.Fatalf("expected a TYPE A for the ASCII store; commands=%v", cmds)
+	}
+	if !hasCmd(cmds[a+1:], "TYPE I") {
+		t.Errorf("transfer type not restored to TYPE I after a failed store; commands=%v", cmds)
+	}
+}
+
+// TestRetrieveIO_RestoresTypeOnSuccess is a success-path regression guard for the
+// defer-based restore: a normal ASCII retrieve must still put the type back to
+// the login default TYPE I after its TYPE A.
+func TestRetrieveIO_RestoresTypeOnSuccess(t *testing.T) {
+	s, srv := dialMock(t)
+	srv.DataFor("RETR", "MY.TXT", "hello\r\n")
+
+	var buf bytes.Buffer
+	if _, _, err := s.RetrieveIO("MY.TXT", &buf, zftp.TypeAscii); err != nil {
+		t.Fatalf("RetrieveIO: %v", err)
+	}
+
+	cmds := srv.Commands()
+	a := cmdIndex(cmds, "TYPE A")
+	if a < 0 {
+		t.Fatalf("expected a TYPE A for the ASCII retrieve; commands=%v", cmds)
+	}
+	if !hasCmd(cmds[a+1:], "TYPE I") {
+		t.Errorf("transfer type not restored to TYPE I after retrieve; commands=%v", cmds)
+	}
+}
+
 // TestStoreIOAt_BinaryOffset is a regression guard: image/binary resume must keep
 // working — REST <n> is sent before STOR and the exact bytes are stored.
 func TestStoreIOAt_BinaryOffset(t *testing.T) {


### PR DESCRIPTION
Lands the remaining unblocked P1 hardening items in one batch, each as its own TDD commit (failing test first → implement → `go test -race ./...`). ZH12 is parked (needs real LPAR LIST captures).

### ZH11 — transfer TYPE restored on the control-failure error path (`transfer.go`)
`RetrieveIO/StoreIO/RetrieveIOAt/StoreIOAt` restored the prior TYPE only after a *successful* transfer. A control-level failure (e.g. RETR/STOR rejected `550` before the data phase, session stays open) returned early and left the session on the wrong TYPE. Restore now happens via a deferred `restoreType` helper placed right after the initial `SetType`; it preserves the original transfer error and skips the round-trip when the session was already torn down.

### ZH13 — remove `Conn()` footgun (`ftp.go`) — breaking
`Conn() net.Conn` let callers Read/Write (corrupt the control stream) or Close (bypass bookkeeping). Removed; replaced with `SetKeepAlive(d time.Duration) error`, `RemoteAddr() net.Addr`, `LocalAddr() net.Addr` operating on the underlying socket (`rawConn`, never swapped on TLS upgrade). Raw deadlines/Read/Write/Close stay internal.

### ZH10 — status getters parse real replies (`internal/utils/utils.go`, `status_get.go`) — breaking
`LastWord` matched `\s(\w+)$`, dropping dotted DSNs, wildcards, and codepage tokens; now returns the last whitespace-delimited token. `SBDataConn()` returns `(string, error)` (it is a codepage, not an int). `UMask()` parses octal (`"022"` → 18).

### ZH14 — `*ReturnError` ergonomics + documented sentinels (`codes.go`, `jes_constants.go`, `jes.go`, `hfs/spool.go`)
`*ReturnError` gained `Is` (match by return code), `Unwrap` (optional transport cause), and an exported `CodeError(rc)` errors.Is target. JES sentinels moved from `fmt.Errorf` to `errors.New` with godoc; the classifier was extracted to `classifyJesOutput` so the sentinels are unit-testable from their producer. Transport failures remain a `%w`-wrapped `io.ErrUnexpectedEOF`, distinguishable from a protocol rejection.

### ZH16 — JES spool parsing robustness (`hfs/spool.go`, `jes.go`)
(a) level-1 `"N spool files"` column parsed into a real `InfoJob.SpoolFiles` field (Class empty for level 1); (b) `ParseInfoJobDetail` locates the job/separator/header by content and skips blank lines; (c) parse errors report the original input line number; (d) `ReturnCode` reports `ErrAbendedJob` even when `ABEND` has no `=NNN`; (e) `WithJesJobPattern` rejects patterns whose capture-group count is not exactly one. Golden files regenerated.

### Gate
`CGO_ENABLED=0 go build ./...`, `go vet ./...`, `staticcheck ./...`, `go test -race ./...`, `govulncheck ./...`, and `cd cli && go build ./...` all green. Adversarial review in an isolated worktree found no defects.

Closes #64 #65 #63 #66 #67