### PR TITLE
harden: P2 batch — critical-path tests, godoc surface, 226/250 completion

### DIFF
--- a/authtls_mock_test.go
+++ b/authtls_mock_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package zftp_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+
+	zftp "gopkg.in/ro-ag/zftp.v2"
+	"gopkg.in/ro-ag/zftp.v2/internal/mockzos"
+)
+
+// newSelfSignedTLS mints a fresh self-signed ECDSA certificate valid for the
+// loopback address and returns a server config that presents it plus a client
+// config that trusts it (ServerName 127.0.0.1, matching the mock's listen
+// address). It lets the AUTH TLS path be exercised end-to-end with no external
+// PKI.
+func newSelfSignedTLS(t *testing.T) (serverCfg, clientCfg *tls.Config) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "mockzos"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		IPAddresses:           []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+		DNSNames:              []string{"localhost"},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse certificate: %v", err)
+	}
+	pool := x509.NewCertPool()
+	pool.AddCert(cert)
+	serverCfg = &tls.Config{
+		Certificates: []tls.Certificate{{Certificate: [][]byte{der}, PrivateKey: key, Leaf: cert}},
+	}
+	clientCfg = &tls.Config{RootCAs: pool, ServerName: "127.0.0.1"}
+	return serverCfg, clientCfg
+}
+
+// TestAuthTLS_LoginAndCommandOverTLS drives the full AUTH TLS handshake against
+// the mock: AUTH TLS (234) upgrades the control connection to TLS, PBSZ/PROT
+// (200) follow, then a complete login and a NOOP all run encrypted. It proves the
+// conn/reader swap in AuthTLS keeps the control stream usable after the upgrade.
+func TestAuthTLS_LoginAndCommandOverTLS(t *testing.T) {
+	srv := mockzos.New(t)
+	serverCfg, clientCfg := newSelfSignedTLS(t)
+	srv.EnableTLS(serverCfg)
+
+	s, err := zftp.Open(srv.Addr())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	if err := s.AuthTLS(clientCfg); err != nil {
+		t.Fatalf("AuthTLS: %v", err)
+	}
+	if err := s.Login("ME", "PW"); err != nil {
+		t.Fatalf("Login over TLS: %v", err)
+	}
+	if _, err := s.SendCommand(zftp.CodeCmdOK, "NOOP"); err != nil {
+		t.Fatalf("NOOP over TLS: %v", err)
+	}
+
+	if !hasCmd(srv.Commands(), "AUTH TLS") {
+		t.Errorf("AUTH TLS was not received by the server; commands=%v", srv.Commands())
+	}
+}

--- a/cmd.go
+++ b/cmd.go
@@ -113,7 +113,12 @@ func (s *FTPSession) CheckLast(expect ReturnCode) (string, error) {
 	return s.checkLast(expect)
 }
 
-func (s *FTPSession) checkLast(expect ReturnCode) (string, error) {
+// checkLast reads the terminal reply after a data transfer. It accepts the reply
+// when its code is expect or any code in alsoAccept — a data transfer may finish
+// with either 226 or 250 (see confirmData) — reports a *ReturnError on any other
+// complete reply (the control stream stays in sync, so the session is kept), and
+// closes the session on an I/O-level failure (the stream is then unrecoverable).
+func (s *FTPSession) checkLast(expect ReturnCode, alsoAccept ...ReturnCode) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), s.dialCfg.replyTimeout())
 	defer cancel()
 
@@ -141,13 +146,24 @@ func (s *FTPSession) checkLast(expect ReturnCode) (string, error) {
 	s.lastMessage.WriteString(msg)
 
 	if err != nil {
-		s.log.Serverf("[res|error] %s", err)
 		var re *ReturnError
-		if !errors.As(err, &re) {
-			// I/O-level failure on the post-transfer reply read: like sendLocked,
-			// the control stream is desynchronized for good, so close the session.
-			s.closeLocked()
+		if errors.As(err, &re) {
+			// A complete, in-sync reply whose code is not expect. Accept it when it is
+			// one of the alternate completion codes (e.g. 226 vs 250); the stream is
+			// still synchronized, so on a genuine mismatch the session is kept open and
+			// the error surfaced.
+			for _, code := range alsoAccept {
+				if re.rc == int(code) {
+					return msg, nil
+				}
+			}
+			s.log.Serverf("[res|error] %s", err)
+			return "", err
 		}
+		s.log.Serverf("[res|error] %s", err)
+		// I/O-level failure on the post-transfer reply read: like sendLocked, the
+		// control stream is desynchronized for good, so close the session.
+		s.closeLocked()
 		return "", err
 	}
 

--- a/codes.go
+++ b/codes.go
@@ -16,6 +16,8 @@ import (
 // ReturnCode is an FTP return code
 type ReturnCode int
 
+// FTP reply codes, per RFC 959 and the z/OS FTP dialect. They name the replies
+// the client expects from the server and matches each command's result against.
 const (
 	CodeListOK                 ReturnCode = 125
 	CodeFileStatusOK           ReturnCode = 150

--- a/completion226_test.go
+++ b/completion226_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package zftp_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	zftp "gopkg.in/ro-ag/zftp.v2"
+)
+
+// TestRetrieveIO_Accepts226Completion verifies a retrieve succeeds when the
+// server closes the transfer with 226 (CodeClosingDataConn) instead of 250. Real
+// z/OS and RFC 959 servers may send either, so the post-transfer reply read must
+// accept both.
+func TestRetrieveIO_Accepts226Completion(t *testing.T) {
+	s, srv := dialMock(t)
+	srv.DataFor("RETR", "MY.BIN", "payload-bytes")
+	srv.CompletionReply("RETR", "226 closing data connection; transfer complete")
+
+	var buf bytes.Buffer
+	if _, _, err := s.RetrieveIO("MY.BIN", &buf, zftp.TypeBinary); err != nil {
+		t.Fatalf("RetrieveIO with a 226 completion: %v", err)
+	}
+	if buf.String() != "payload-bytes" {
+		t.Errorf("data = %q, want payload-bytes", buf.String())
+	}
+}
+
+// TestStoreIO_Accepts226Completion verifies a store succeeds when the server
+// closes the transfer with 226 instead of 250.
+func TestStoreIO_Accepts226Completion(t *testing.T) {
+	s, srv := dialMock(t)
+	srv.CompletionReply("STOR", "226 closing data connection; transfer complete")
+
+	if _, _, err := s.StoreIO("OUT.BIN", strings.NewReader("data"), zftp.TypeBinary); err != nil {
+		t.Fatalf("StoreIO with a 226 completion: %v", err)
+	}
+	if stored, ok := srv.Stored("OUT.BIN"); !ok || string(stored) != "data" {
+		t.Errorf("stored = %q (ok=%v), want data", stored, ok)
+	}
+}
+
+// TestList_Accepts226Completion verifies a LIST succeeds when the data transfer
+// is closed with 226 instead of 250 — the same completion path (confirmData) as
+// RETR/STOR.
+func TestList_Accepts226Completion(t *testing.T) {
+	s, srv := dialMock(t)
+	listing := "Volume Unit    Referred Ext Used Recfm Lrecl BlkSz Dsorg Dsname\r\n" +
+		"FA00FF 3390   2023/06/02  1  360  VB    8004 27998  PS  'ABCD.EF.SEQ'\r\n"
+	srv.DataFor("LIST", "", listing)
+	srv.CompletionReply("LIST", "226 closing data connection")
+
+	lines, err := s.List("ABCD.EF.*")
+	if err != nil {
+		t.Fatalf("List with a 226 completion: %v", err)
+	}
+	if len(lines) != 2 {
+		t.Errorf("got %d lines, want 2 (header + 1 row)", len(lines))
+	}
+}

--- a/doc_coverage_test.go
+++ b/doc_coverage_test.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package zftp_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestExportedIdentifiersAreDocumented enforces that every exported identifier in
+// the zftp package's own source files carries a doc comment, so `go doc` is
+// complete for the public surface. It scans the package source directly (skipping
+// test files and generated files), and treats a const/var/field as documented if
+// it has a doc comment, a trailing line comment, or belongs to a documented
+// declaration block — matching what godoc renders.
+func TestExportedIdentifiersAreDocumented(t *testing.T) {
+	fset := token.NewFileSet()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package dir: %v", err)
+	}
+
+	var undocumented []string
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		f, err := parser.ParseFile(fset, name, nil, parser.ParseComments)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		if isGeneratedFile(f) {
+			continue
+		}
+		for _, d := range f.Decls {
+			switch decl := d.(type) {
+			case *ast.FuncDecl:
+				if !ast.IsExported(decl.Name.Name) {
+					continue
+				}
+				if decl.Recv != nil {
+					// Only methods on exported types are part of the public surface.
+					if !ast.IsExported(strings.TrimPrefix(receiverType(decl.Recv), "*")) {
+						continue
+					}
+				}
+				if decl.Doc == nil {
+					undocumented = append(undocumented, name+": func "+funcLabel(decl))
+				}
+			case *ast.GenDecl:
+				collectUndocumentedGenDecl(name, decl, &undocumented)
+			}
+		}
+	}
+
+	if len(undocumented) > 0 {
+		sort.Strings(undocumented)
+		t.Fatalf("exported identifiers without a doc comment (%d):\n%s",
+			len(undocumented), strings.Join(undocumented, "\n"))
+	}
+}
+
+func collectUndocumentedGenDecl(file string, decl *ast.GenDecl, out *[]string) {
+	for _, spec := range decl.Specs {
+		switch s := spec.(type) {
+		case *ast.TypeSpec:
+			if !ast.IsExported(s.Name.Name) {
+				continue
+			}
+			if s.Doc == nil && decl.Doc == nil {
+				*out = append(*out, file+": type "+s.Name.Name)
+			}
+			if st, ok := s.Type.(*ast.StructType); ok && st.Fields != nil {
+				for _, fld := range st.Fields.List {
+					for _, fn := range fld.Names {
+						if ast.IsExported(fn.Name) && fld.Doc == nil && fld.Comment == nil {
+							*out = append(*out, file+": field "+s.Name.Name+"."+fn.Name)
+						}
+					}
+				}
+			}
+		case *ast.ValueSpec:
+			exported := false
+			for _, n := range s.Names {
+				if ast.IsExported(n.Name) {
+					exported = true
+				}
+			}
+			if !exported {
+				continue
+			}
+			// A trailing line comment, an own doc comment, or a block-level doc all
+			// count — each shows up in godoc.
+			if s.Doc == nil && s.Comment == nil && decl.Doc == nil {
+				names := make([]string, 0, len(s.Names))
+				for _, n := range s.Names {
+					names = append(names, n.Name)
+				}
+				*out = append(*out, file+": value "+strings.Join(names, ","))
+			}
+		}
+	}
+}
+
+// isGeneratedFile reports whether f was produced by a code generator (e.g.
+// stringer), per the "// Code generated ... DO NOT EDIT." convention.
+func isGeneratedFile(f *ast.File) bool {
+	for _, cg := range f.Comments {
+		for _, c := range cg.List {
+			if strings.HasPrefix(c.Text, "// Code generated ") && strings.HasSuffix(c.Text, "DO NOT EDIT.") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func receiverType(recv *ast.FieldList) string {
+	if recv == nil || len(recv.List) == 0 {
+		return ""
+	}
+	switch t := recv.List[0].Type.(type) {
+	case *ast.Ident:
+		return t.Name
+	case *ast.StarExpr:
+		if id, ok := t.X.(*ast.Ident); ok {
+			return "*" + id.Name
+		}
+	}
+	return ""
+}
+
+func funcLabel(decl *ast.FuncDecl) string {
+	if decl.Recv != nil {
+		return receiverType(decl.Recv) + "." + decl.Name.Name
+	}
+	return decl.Name.Name
+}

--- a/get.go
+++ b/get.go
@@ -122,11 +122,9 @@ func (s *FTPSession) GetAndGzip(remote string, localFile string, mode TransferTy
 		return fmt.Errorf("failed to retrieve and compress file: %w", err)
 	}
 
-	err = gzWriter.Flush()
-	if err != nil {
-		return fmt.Errorf("failed to flush gzip writer: %w", err)
-	}
-
+	// Close flushes any buffered compressed data and writes the gzip footer, so the
+	// file is complete before VerifyGzSize reads it. A separate Flush beforehand is
+	// redundant (Flush does not write the footer; Close does both).
 	err = gzWriter.Close()
 	if err != nil {
 		return fmt.Errorf("failed to close gzip writer: %w", err)

--- a/get_put_mock_test.go
+++ b/get_put_mock_test.go
@@ -4,7 +4,9 @@ package zftp_test
 
 import (
 	"bytes"
+	"compress/gzip"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -44,6 +46,92 @@ func TestPutGet_BinaryRoundTrip(t *testing.T) {
 	}
 	if !bytes.Equal(got, content) {
 		t.Errorf("downloaded = % x, want % x", got, content)
+	}
+}
+
+// TestGetAndGzip_RoundTrip retrieves a payload and compresses it on the fly, then
+// asserts the resulting .gz decompresses byte-for-byte to the original — covering
+// the gzip writer/footer path and VerifyGzSize, which previously had no test.
+func TestGetAndGzip_RoundTrip(t *testing.T) {
+	s, srv := dialMock(t)
+	dir := t.TempDir()
+	payload := []byte("hello z/OS - gzip round trip\nline two\nline three\n")
+	srv.DataFor("RETR", "MY.DATA", string(payload))
+
+	local := filepath.Join(dir, "out") // GetAndGzip appends ".gz"
+	if err := s.GetAndGzip("MY.DATA", local, zftp.TypeBinary); err != nil {
+		t.Fatalf("GetAndGzip: %v", err)
+	}
+
+	f, err := os.Open(local + ".gz")
+	if err != nil {
+		t.Fatalf("open gz: %v", err)
+	}
+	defer f.Close()
+	zr, err := gzip.NewReader(f)
+	if err != nil {
+		t.Fatalf("gzip.NewReader: %v", err)
+	}
+	got, err := io.ReadAll(zr)
+	if err != nil {
+		t.Fatalf("read gz: %v", err)
+	}
+	if err := zr.Close(); err != nil {
+		t.Errorf("gzip reader Close (checksum/size mismatch?): %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Errorf("decompressed = %q, want %q", got, payload)
+	}
+}
+
+// TestGetAt_BinaryOffset_WritesAtOffset covers the binary resume path of the
+// local-file GetAt: with a positive offset it must send REST <n>, seek the local
+// file to the offset (not truncate), and write the retrieved bytes there, leaving
+// the bytes already present before the offset intact.
+func TestGetAt_BinaryOffset_WritesAtOffset(t *testing.T) {
+	s, srv := dialMock(t)
+	dir := t.TempDir()
+	local := filepath.Join(dir, "out.bin")
+	if err := os.WriteFile(local, []byte("HEAD"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	srv.DataFor("RETR", "BIG.BIN", "TAILDATA")
+
+	if err := s.GetAt("BIG.BIN", local, zftp.TypeBinary, 4); err != nil {
+		t.Fatalf("GetAt: %v", err)
+	}
+	if !hasCmd(srv.Commands(), "REST 4") {
+		t.Errorf("expected REST 4 in command sequence; got %v", srv.Commands())
+	}
+	got, err := os.ReadFile(local)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "HEADTAILDATA" {
+		t.Errorf("local file = %q, want HEADTAILDATA", got)
+	}
+}
+
+// TestPutAt_BinaryOffset_UploadsFromOffset covers the binary resume path of the
+// local-file PutAt: with a positive offset it must seek the source to the offset
+// and send only the bytes from there, prefixed by REST <n>.
+func TestPutAt_BinaryOffset_UploadsFromOffset(t *testing.T) {
+	s, srv := dialMock(t)
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.bin")
+	if err := os.WriteFile(src, []byte("HEADTAILDATA"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.PutAt(src, "BIG.BIN", zftp.TypeBinary, 4); err != nil {
+		t.Fatalf("PutAt: %v", err)
+	}
+	if !hasCmd(srv.Commands(), "REST 4") {
+		t.Errorf("expected REST 4 in command sequence; got %v", srv.Commands())
+	}
+	stored, ok := srv.Stored("BIG.BIN")
+	if !ok || string(stored) != "TAILDATA" {
+		t.Errorf("stored = %q (ok=%v), want TAILDATA", stored, ok)
 	}
 }
 

--- a/internal/mockzos/script.go
+++ b/internal/mockzos/script.go
@@ -2,7 +2,46 @@
 
 package mockzos
 
-import "strings"
+import (
+	"crypto/tls"
+	"strings"
+)
+
+// EnableTLS makes the server accept AUTH TLS and upgrade the control connection
+// to a TLS server session using cfg (which must carry a certificate). It lets
+// tests exercise the client's AuthTLS/PBSZ/PROT path over a real, in-process TLS
+// handshake. Call it before the client dials.
+func (s *Server) EnableTLS(cfg *tls.Config) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.tlsConfig = cfg
+}
+
+// CompletionReply overrides the closing reply the server sends after a transfer
+// completes for the given verb (RETR/LIST/NLST or STOR/STOU/APPE). The default is
+// a single "250 transfer completed successfully" line; pass replies to script a
+// different terminal code (e.g. "226 ...") or a multiline z/OS JES message that
+// carries a job id. The key is a verb.
+//
+//	srv.CompletionReply("STOR", "250-IT IS KNOWN TO JES AS JOB12345", "250 SUBMIT successful")
+//	srv.CompletionReply("RETR", "226 Closing data connection; transfer complete")
+func (s *Server) CompletionReply(verb string, replies ...string) {
+	key := strings.ToUpper(strings.TrimSpace(verb))
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.completionReply[key] = replies
+}
+
+// completionReplyFor returns the scripted closing reply for a transfer verb, or
+// the default "250 transfer completed successfully" when none is set.
+func (s *Server) completionReplyFor(verb string) []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if r, ok := s.completionReply[verb]; ok {
+		return r
+	}
+	return []string{"250 transfer completed successfully"}
+}
 
 // Script registers raw control reply line(s) for a command. The match key may be
 // a full command line ("XSTA (BLOCKSIze") or just a verb ("STAT"); a full-line

--- a/internal/mockzos/server.go
+++ b/internal/mockzos/server.go
@@ -13,6 +13,7 @@ package mockzos
 
 import (
 	"bufio"
+	"crypto/tls"
 	"fmt"
 	"net"
 	"strings"
@@ -33,19 +34,21 @@ type Server struct {
 	closed atomic.Bool
 	wg     sync.WaitGroup
 
-	mu            sync.Mutex
-	lineScripts   map[string][]string // full command line (upper) -> raw reply lines
-	verbScripts   map[string][]string // verb (upper) -> raw reply lines
-	dataByLine    map[string]string   // full command line (upper) -> payload to send
-	dataByVerb    map[string]string   // verb (upper) -> payload to send
-	stored        map[string][]byte   // STOR arg (upper) -> captured payload
-	withheld      map[string]bool     // full line or verb (upper) -> swallow without replying
-	hangup        map[string]bool     // full line or verb (upper) -> drop the control conn without replying
-	dropAfterData map[string]bool     // download verb (upper) -> drop control after data, before the closing reply
-	truncate      map[string]bool     // download verb (upper) -> RST the data conn instead of a clean close
-	hangData      map[string]bool     // download verb (upper) -> hold the data conn open after sending payload
-	withholdReply map[string]bool     // download verb (upper) -> deliver data + clean close, but send no closing reply
-	received      []string            // every command line received, in order
+	mu              sync.Mutex
+	lineScripts     map[string][]string // full command line (upper) -> raw reply lines
+	verbScripts     map[string][]string // verb (upper) -> raw reply lines
+	dataByLine      map[string]string   // full command line (upper) -> payload to send
+	dataByVerb      map[string]string   // verb (upper) -> payload to send
+	stored          map[string][]byte   // STOR arg (upper) -> captured payload
+	withheld        map[string]bool     // full line or verb (upper) -> swallow without replying
+	hangup          map[string]bool     // full line or verb (upper) -> drop the control conn without replying
+	dropAfterData   map[string]bool     // download verb (upper) -> drop control after data, before the closing reply
+	truncate        map[string]bool     // download verb (upper) -> RST the data conn instead of a clean close
+	hangData        map[string]bool     // download verb (upper) -> hold the data conn open after sending payload
+	withholdReply   map[string]bool     // download verb (upper) -> deliver data + clean close, but send no closing reply
+	completionReply map[string][]string // transfer verb (upper) -> override the closing reply (default "250 ...")
+	tlsConfig       *tls.Config         // when set, AUTH TLS upgrades the control connection
+	received        []string            // every command line received, in order
 }
 
 // New starts a Server on 127.0.0.1:0 and registers cleanup with the test.
@@ -56,19 +59,20 @@ func New(tb testing.TB) *Server {
 		tb.Fatalf("mockzos listen: %v", err)
 	}
 	s := &Server{
-		tb:            tb,
-		ln:            ln,
-		lineScripts:   map[string][]string{},
-		verbScripts:   map[string][]string{},
-		dataByLine:    map[string]string{},
-		dataByVerb:    map[string]string{},
-		stored:        map[string][]byte{},
-		withheld:      map[string]bool{},
-		hangup:        map[string]bool{},
-		dropAfterData: map[string]bool{},
-		truncate:      map[string]bool{},
-		hangData:      map[string]bool{},
-		withholdReply: map[string]bool{},
+		tb:              tb,
+		ln:              ln,
+		lineScripts:     map[string][]string{},
+		verbScripts:     map[string][]string{},
+		dataByLine:      map[string]string{},
+		dataByVerb:      map[string]string{},
+		stored:          map[string][]byte{},
+		withheld:        map[string]bool{},
+		hangup:          map[string]bool{},
+		dropAfterData:   map[string]bool{},
+		truncate:        map[string]bool{},
+		hangData:        map[string]bool{},
+		withholdReply:   map[string]bool{},
+		completionReply: map[string][]string{},
 	}
 	s.wg.Add(1)
 	go s.serve()
@@ -101,15 +105,17 @@ func (s *Server) serve() {
 	}
 }
 
-// session holds per-connection state (the pending passive data listener).
+// session holds per-connection state: the (possibly TLS-upgraded) control
+// connection, its buffered reader, and the pending passive data listener.
 type session struct {
 	conn net.Conn
+	r    *bufio.Reader
 	pasv net.Listener
 }
 
 func (s *Server) handle(conn net.Conn) {
 	defer conn.Close()
-	sess := &session{conn: conn}
+	sess := &session{conn: conn, r: bufio.NewReader(conn)}
 	defer func() {
 		if sess.pasv != nil {
 			_ = sess.pasv.Close()
@@ -118,9 +124,11 @@ func (s *Server) handle(conn net.Conn) {
 
 	writeLines(conn, []string{"220 mockzos FTP service ready"})
 
-	r := bufio.NewReader(conn)
 	for {
-		line, err := r.ReadString('\n')
+		// Read from sess.r, not a captured reader: AUTH TLS swaps both the
+		// connection and its reader, so subsequent commands must be read through
+		// the upgraded reader.
+		line, err := sess.r.ReadString('\n')
 		if err != nil {
 			return
 		}
@@ -156,6 +164,8 @@ func (s *Server) dispatch(sess *session, line, verb, arg string) bool {
 	}
 
 	switch verb {
+	case "AUTH":
+		s.handleAuth(sess, arg)
 	case "USER":
 		writeLines(sess.conn, []string{"331 send password"})
 	case "PASS":
@@ -185,7 +195,7 @@ func (s *Server) dispatch(sess *session, line, verb, arg string) bool {
 	case "LIST", "NLST", "RETR":
 		s.handleDownload(sess, line, verb, arg)
 	case "STOR", "STOU", "APPE":
-		s.handleUpload(sess, arg)
+		s.handleUpload(sess, verb, arg)
 	case "QUIT":
 		writeLines(sess.conn, []string{"221 goodbye"})
 		return true
@@ -193,6 +203,30 @@ func (s *Server) dispatch(sess *session, line, verb, arg string) bool {
 		writeLines(sess.conn, []string{"200 command okay"})
 	}
 	return false
+}
+
+// handleAuth answers AUTH TLS when TLS has been enabled via EnableTLS: it replies
+// 234 and upgrades the control connection to a TLS server session, swapping the
+// connection and its reader so every later command on this session runs
+// encrypted. AUTH with any other mechanism, or when TLS is not enabled, is
+// rejected with 504.
+func (s *Server) handleAuth(sess *session, arg string) {
+	s.mu.Lock()
+	cfg := s.tlsConfig
+	s.mu.Unlock()
+	if cfg == nil || !strings.EqualFold(strings.TrimSpace(arg), "TLS") {
+		writeLines(sess.conn, []string{"504 security mechanism not supported"})
+		return
+	}
+	writeLines(sess.conn, []string{"234 security environment established, ready for TLS negotiation"})
+	tconn := tls.Server(sess.conn, cfg)
+	if err := tconn.Handshake(); err != nil {
+		s.tb.Logf("mockzos: TLS handshake failed: %v", err)
+		_ = sess.conn.Close()
+		return
+	}
+	sess.conn = tconn
+	sess.r = bufio.NewReader(tconn)
 }
 
 // handlePasv opens a fresh loopback data listener and advertises it.
@@ -259,11 +293,11 @@ func (s *Server) handleDownload(sess *session, line, verb, arg string) {
 	if s.isWithholdReplyAfterData(verb) {
 		return
 	}
-	writeLines(sess.conn, []string{"250 transfer completed successfully"})
+	writeLines(sess.conn, s.completionReplyFor(verb))
 }
 
 // handleUpload captures the payload the client sends over the data connection.
-func (s *Server) handleUpload(sess *session, arg string) {
+func (s *Server) handleUpload(sess *session, verb, arg string) {
 	dc := s.acceptData(sess)
 	if dc == nil {
 		writeLines(sess.conn, []string{"425 cannot open data connection"})
@@ -276,7 +310,7 @@ func (s *Server) handleUpload(sess *session, arg string) {
 	s.mu.Lock()
 	s.stored[strings.ToUpper(strings.TrimSpace(arg))] = []byte(buf.String())
 	s.mu.Unlock()
-	writeLines(sess.conn, []string{"250 transfer completed successfully"})
+	writeLines(sess.conn, s.completionReplyFor(verb))
 }
 
 // acceptData accepts the pending passive data connection.

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -74,11 +74,17 @@ func WrapText(str string) string {
 	return builder.String()
 }
 
-// MaxUint32 is the maximum value that can be represented by a 32-bit unsigned integer.
+// MaxUint32 is 2^32, the modulus of the gzip footer's uncompressed-size (ISIZE)
+// field.
 const MaxUint32 = 4294967296
 
-// VerifyGzSize verifies that the size of the transferred file matches the size in the gzip footer.
-// This is necessary because the gzip format only supports files up to 2^32 bytes.
+// VerifyGzSize checks that the uncompressed size recorded in the gzip footer
+// (ISIZE, the last four bytes) matches the number of bytes transferred. Because
+// ISIZE stores the original size modulo 2^32, this check is only meaningful for
+// streams smaller than 4 GiB: at or above 4 GiB both the footer and the expected
+// value wrap by the same modulus, so the comparison still passes but no longer
+// proves the sizes match. Callers needing integrity for 4 GiB+ payloads must
+// verify by other means (e.g. a checksum).
 func VerifyGzSize(lg *log.Logger, file *os.File, size int64) error {
 	// Sanity check
 	const footerSize = 4

--- a/jes.go
+++ b/jes.go
@@ -17,7 +17,9 @@ import (
 
 // JesJob represents a JES job on the FTP server
 type JesJob struct {
-	ID  string
+	// ID is the JES job id (e.g. JOB12345) parsed from the submit reply.
+	ID string
+	// DSN is the internal-reader dataset name the JCL was written to.
 	DSN string
 }
 
@@ -71,11 +73,17 @@ func (s *FTPSession) SubmitJCLFile(jclFile string, options ...JesSpec) (*JesJob,
 	return s.SubmitIO(jcl, options...)
 }
 
+// JobResult is the outcome of a JES submit-and-fetch (SubmitJesGetByDSN): the
+// submitted job plus its retrieved spool output, display name, and return code.
 type JobResult struct {
 	JesJob
-	Spool       []string
+	// Spool holds the job's spool files, one entry per spool dataset.
+	Spool []string
+	// DisplayName is the job name as reported in the spool output.
 	DisplayName string
-	ReturnCode  int
+	// ReturnCode is the job's numeric return code, or -1 when the job did not end
+	// with a parseable RC (e.g. an abend or a JCL/allocation error).
+	ReturnCode int
 }
 
 var (
@@ -260,28 +268,28 @@ func (s *FTPSession) GetJobStatus(jobID string) (*hfs.InfoJobDetail, error) {
 
 // WithJesEntryLimit sets the maximum number of entries to retrieve from JES
 func WithJesEntryLimit(limit int) JesSpec {
-	return JesOptionFunc(func(s *FTPSession) error {
+	return jesOptionFunc(func(s *FTPSession) error {
 		return s.SetStatusOf().JesEntryLimit(limit)
 	})
 }
 
 // WithJesGetByDSN sets the JESGETBYDSN parameter to true or false
 func WithJesGetByDSN(option bool) JesSpec {
-	return JesOptionFunc(func(s *FTPSession) error {
+	return jesOptionFunc(func(s *FTPSession) error {
 		return s.SetStatusOf().JesGetByDSN(option)
 	})
 }
 
 // WithJesLrecl sets the LRECL parameter for JES
 func WithJesLrecl(len int) JesSpec {
-	return JesOptionFunc(func(s *FTPSession) error {
+	return jesOptionFunc(func(s *FTPSession) error {
 		return s.SetStatusOf().JesLrecl(len)
 	})
 }
 
 // WithJesPutGetTimeOut sets the timeout for JES PUT and GET commands
 func WithJesPutGetTimeOut(seconds int) JesSpec {
-	return JesOptionFunc(func(s *FTPSession) error {
+	return jesOptionFunc(func(s *FTPSession) error {
 		return s.SetStatusOf().JesPutGetTimeOut(seconds)
 	})
 }
@@ -292,7 +300,7 @@ func WithJesPutGetTimeOut(seconds int) JesSpec {
 // none or more than one group is rejected with an error rather than silently
 // breaking job-id extraction.
 func WithJesJobPattern(pattern string) JesSpec {
-	return JesOptionFunc(func(s *FTPSession) error {
+	return jesOptionFunc(func(s *FTPSession) error {
 		re, err := regexp.Compile(pattern)
 		if err != nil {
 			return err
@@ -305,12 +313,17 @@ func WithJesJobPattern(pattern string) JesSpec {
 	})
 }
 
+// JesSpec is a JES submission option applied to a session before a job is
+// submitted. Construct one with the With… helpers (e.g. WithJesEntryLimit,
+// WithJesGetByDSN).
 type JesSpec interface {
 	Apply(*FTPSession) error
 }
 
-type JesOptionFunc func(*FTPSession) error
+// jesOptionFunc adapts a plain function to the JesSpec interface. Callers use the
+// With… constructors rather than this type directly.
+type jesOptionFunc func(*FTPSession) error
 
-func (f JesOptionFunc) Apply(s *FTPSession) error {
+func (f jesOptionFunc) Apply(s *FTPSession) error {
 	return f(s)
 }

--- a/jes_mock_test.go
+++ b/jes_mock_test.go
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package zftp_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	zftp "gopkg.in/ro-ag/zftp.v2"
+)
+
+// TestSubmitJCL_ExtractsJobID submits JCL over the internal reader (STOR in JES
+// filetype) and verifies the job id is pulled from the z/OS submit reply
+// ("IT IS KNOWN TO JES AS JOBnnnnn") by the default (JOB\d{5}) pattern.
+func TestSubmitJCL_ExtractsJobID(t *testing.T) {
+	s, srv := dialMock(t)
+	srv.CompletionReply("STOR",
+		"250-IT IS KNOWN TO JES AS JOB12345",
+		"250 SUBMIT successful, job submitted")
+
+	job, err := s.SubmitJCL("//RUN JOB (ACCT),CLASS=A\n//S1 EXEC PGM=IEFBR14\n")
+	if err != nil {
+		t.Fatalf("SubmitJCL: %v", err)
+	}
+	if job.ID != "JOB12345" {
+		t.Errorf("job.ID = %q, want JOB12345", job.ID)
+	}
+	// The submit must go out in JES filetype (SITE FILETYPE=JES) before the STOR.
+	if !hasCmd(srv.Commands(), "SITE FILETYPE=JES") {
+		t.Errorf("expected SITE FILETYPE=JES before submit; commands=%v", srv.Commands())
+	}
+}
+
+// TestGetJobStatus_Level2Detail lists a single job's status (JesInterfaceLevel=2)
+// and verifies the record and its return code are parsed: GetJobStatus must set
+// JES filetype, list the job id, and hand the listing to ParseInfoJobDetail.
+func TestGetJobStatus_Level2Detail(t *testing.T) {
+	s, srv := dialMock(t)
+	detail := "JOBNAME  JOBID    OWNER    STATUS   CLASS\r\n" +
+		"MYJOB    JOB12345 ME       OUTPUT   RC=0000\r\n"
+	srv.DataFor("LIST", "JOB12345", detail)
+
+	jd, err := s.GetJobStatus("JOB12345")
+	if err != nil {
+		t.Fatalf("GetJobStatus: %v", err)
+	}
+	jb := jd.Job()
+	if got := jb.JobId.String(); got != "JOB12345" {
+		t.Errorf("JobId = %q, want JOB12345", got)
+	}
+	if got := jb.Name.String(); got != "MYJOB" {
+		t.Errorf("Name = %q, want MYJOB", got)
+	}
+	rc, err := jd.ReturnCode()
+	if err != nil {
+		t.Fatalf("ReturnCode: %v", err)
+	}
+	if rc != 0 {
+		t.Errorf("ReturnCode = %d, want 0", rc)
+	}
+}
+
+// TestSubmitJesGetByDSN_Success parses a clean job: the job id comes from the
+// control reply, the display name and RC=0000 from the spool payload.
+func TestSubmitJesGetByDSN_Success(t *testing.T) {
+	s, srv := dialMock(t)
+	srv.CompletionReply("RETR",
+		"250-It is known to JES as JOB12345",
+		"250-When JOB12345 is done, retrieval of its output begins",
+		"250 transfer complete")
+	spool := "1                    J E S 2  J O B  L O G\n" +
+		"$HASP395 MYJOB ENDED - RC=0000\n" +
+		" !! END OF JES SPOOL FILE !!\n"
+	srv.DataFor("RETR", "", spool)
+
+	job, err := s.SubmitJesGetByDSN("//MYJOB JOB (ACCT)\n//S1 EXEC PGM=IEFBR14\n")
+	if err != nil {
+		t.Fatalf("SubmitJesGetByDSN: %v", err)
+	}
+	if job.ID != "JOB12345" {
+		t.Errorf("job.ID = %q, want JOB12345", job.ID)
+	}
+	if job.DisplayName != "MYJOB" {
+		t.Errorf("job.DisplayName = %q, want MYJOB", job.DisplayName)
+	}
+	if job.ReturnCode != 0 {
+		t.Errorf("job.ReturnCode = %d, want 0", job.ReturnCode)
+	}
+}
+
+// TestSubmitJesGetByDSN_IEFError classifies an allocation/JCL (IEFxxx) failure:
+// the spool carries an IEF message and a HASP395 ENDED line with no parseable RC,
+// so the result reports ErrIEF and ReturnCode -1.
+func TestSubmitJesGetByDSN_IEFError(t *testing.T) {
+	s, srv := dialMock(t)
+	srv.CompletionReply("RETR",
+		"250-When JOB12345 is done, retrieval of its output begins",
+		"250 transfer complete")
+	spool := "IEF001I JOB FAILED - ALLOCATION ERROR\n" +
+		"$HASP395 MYJOB ENDED\n" +
+		" !! END OF JES SPOOL FILE !!\n"
+	srv.DataFor("RETR", "", spool)
+
+	job, err := s.SubmitJesGetByDSN("//MYJOB JOB (ACCT)\n//S1 EXEC PGM=IEFBR14\n")
+	if !errors.Is(err, zftp.ErrIEF) {
+		t.Fatalf("err = %v, want ErrIEF", err)
+	}
+	if job.ReturnCode != -1 {
+		t.Errorf("job.ReturnCode = %d, want -1", job.ReturnCode)
+	}
+}
+
+// TestSubmitJesGetByDSN_Abend classifies an abend (ABAxxx) failure: the spool
+// carries an ABA message and a HASP395 ENDED line with no parseable RC, so the
+// result reports ErrAba and ReturnCode -1.
+func TestSubmitJesGetByDSN_Abend(t *testing.T) {
+	s, srv := dialMock(t)
+	srv.CompletionReply("RETR",
+		"250-When JOB12345 is done, retrieval of its output begins",
+		"250 transfer complete")
+	spool := "ABA001I TASK ABENDED\n" +
+		"$HASP395 MYJOB ENDED\n" +
+		" !! END OF JES SPOOL FILE !!\n"
+	srv.DataFor("RETR", "", spool)
+
+	job, err := s.SubmitJesGetByDSN("//MYJOB JOB (ACCT)\n//S1 EXEC PGM=IEFBR14\n")
+	if !errors.Is(err, zftp.ErrAba) {
+		t.Fatalf("err = %v, want ErrAba", err)
+	}
+	if job.ReturnCode != -1 {
+		t.Errorf("job.ReturnCode = %d, want -1", job.ReturnCode)
+	}
+	if !strings.Contains(job.DisplayName, "MYJOB") {
+		t.Errorf("job.DisplayName = %q, want it to contain MYJOB", job.DisplayName)
+	}
+}

--- a/put.go
+++ b/put.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 )
 
+// Block-size bounds accepted by WithBlkSize for dataset transfers.
 const (
 	MinBlockSize = 1
 	MaxBlockSize = 32768
@@ -130,6 +131,8 @@ type DataSpec interface {
 	Apply() (string, error)
 }
 
+// Recfm is a z/OS record format (RECFM) usable as a DataSpec via the WithRecfm…
+// constants; its Apply renders the SITE RECFM= subcommand.
 type Recfm string
 
 const (
@@ -175,6 +178,8 @@ func isValidRECFM(recfm Recfm) (string, bool) {
 	}
 }
 
+// Apply renders the SITE subcommand for this record format, or an error if the
+// value is not a recognized RECFM.
 func (rec Recfm) Apply() (string, error) {
 	_, ok := isValidRECFM(rec)
 	if !ok {

--- a/status_get.go
+++ b/status_get.go
@@ -20,6 +20,7 @@ type ServerStatus struct {
 	xstat func(string) (string, error)
 }
 
+// ASATrans reports whether ASA carriage-control handling is enabled (XSTA ASATRANS).
 func (s *ServerStatus) ASATrans() (string, error) {
 	resp, err := s.xstat("ASATrans")
 	if err != nil {
@@ -28,6 +29,7 @@ func (s *ServerStatus) ASATrans() (string, error) {
 	return utils.RemoveNewLine(resp), nil
 }
 
+// AutoMount reports whether volumes are automatically mounted for allocation (XSTA AUTOMOUNT).
 func (s *ServerStatus) AutoMount() (string, error) {
 	resp, err := s.xstat("AUTOMount")
 	if err != nil {
@@ -36,6 +38,7 @@ func (s *ServerStatus) AutoMount() (string, error) {
 	return utils.RemoveNewLine(resp), nil
 }
 
+// AutoRecall reports whether migrated datasets are automatically recalled (XSTA AUTORECALL).
 func (s *ServerStatus) AutoRecall() (string, error) {
 	resp, err := s.xstat("AUTORecall")
 	if err != nil {
@@ -44,6 +47,7 @@ func (s *ServerStatus) AutoRecall() (string, error) {
 	return utils.RemoveNewLine(resp), nil
 }
 
+// BLocks reports whether primary/secondary space is allocated in blocks (XSTA BLOCKS).
 func (s *ServerStatus) BLocks() (string, error) {
 	resp, err := s.xstat("BLocks")
 	if err != nil {
@@ -52,6 +56,7 @@ func (s *ServerStatus) BLocks() (string, error) {
 	return utils.RemoveNewLine(resp), nil
 }
 
+// BlockSize returns the block size (BLKSIZE) from the record-format status line (XSTA BLOCKSIZE).
 func (s *ServerStatus) BlockSize() (int, error) {
 	resp, err := s.xstat("BLOCKSIze")
 	if err != nil {
@@ -66,6 +71,7 @@ func (s *ServerStatus) BlockSize() (int, error) {
 	return strconv.Atoi(m[3])
 }
 
+// BufNo returns the number of access-method buffers configured (XSTA BUFNO).
 func (s *ServerStatus) BufNo() (int, error) {
 	resp, err := s.xstat("BUfno")
 	if err != nil {
@@ -74,6 +80,7 @@ func (s *ServerStatus) BufNo() (int, error) {
 	return utils.LastWordToInt(resp)
 }
 
+// CheckpointInterval returns the checkpoint interval, in records, for the data connection (XSTA CHKPTINT).
 func (s *ServerStatus) CheckpointInterval() (int, error) {
 	resp, err := s.xstat("CHKptint")
 	if err != nil {
@@ -82,6 +89,7 @@ func (s *ServerStatus) CheckpointInterval() (int, error) {
 	return utils.LastWordToInt(resp)
 }
 
+// ConditionDisposition returns the disposition applied to a dataset when a transfer fails (XSTA CONDDISP).
 func (s *ServerStatus) ConditionDisposition() (string, error) {
 	resp, err := s.xstat("CONDdisp")
 	if err != nil {
@@ -90,6 +98,7 @@ func (s *ServerStatus) ConditionDisposition() (string, error) {
 	return utils.RemoveNewLine(resp), nil
 }
 
+// Cylinders reports whether primary/secondary space is allocated in cylinders (XSTA CYLINDERS).
 func (s *ServerStatus) Cylinders() (string, error) {
 	resp, err := s.xstat("CYlinders")
 	if err != nil {
@@ -98,6 +107,7 @@ func (s *ServerStatus) Cylinders() (string, error) {
 	return utils.RemoveNewLine(resp), nil
 }
 
+// DataClass returns the SMS data class used for new dataset allocation (XSTA DATACLASS).
 func (s *ServerStatus) DataClass() (string, error) {
 	resp, err := s.xstat("DATAClass")
 	if err != nil {
@@ -106,6 +116,7 @@ func (s *ServerStatus) DataClass() (string, error) {
 	return utils.LastWord(resp), nil
 }
 
+// DataKeepAlive returns the data-connection TCP keep-alive interval, in seconds (XSTA DATAKEEPALIVE).
 func (s *ServerStatus) DataKeepAlive() (int, error) {
 	resp, err := s.xstat("DATAKEEPALIVE")
 	if err != nil {
@@ -114,6 +125,7 @@ func (s *ServerStatus) DataKeepAlive() (int, error) {
 	return utils.LastWordToInt(resp)
 }
 
+// DatasetMode reports whether the server is in dataset mode rather than directory mode (XSTA DATASETMODE).
 func (s *ServerStatus) DatasetMode() (string, error) {
 	resp, err := s.xstat("DATASetmode")
 	if err != nil {
@@ -122,6 +134,7 @@ func (s *ServerStatus) DatasetMode() (string, error) {
 	return utils.RemoveNewLine(resp), nil
 }
 
+// DB2 returns the DB2 subsystem name used for SQL queries (XSTA DB2).
 func (s *ServerStatus) DB2() (string, error) {
 	resp, err := s.xstat("DB2")
 	if err != nil {
@@ -130,6 +143,7 @@ func (s *ServerStatus) DB2() (string, error) {
 	return utils.LastWord(resp), nil
 }
 
+// DoubleByteSubstitution reports whether double-byte substitution is enabled (XSTA DBSUB).
 func (s *ServerStatus) DoubleByteSubstitution() (bool, error) {
 	resp, err := s.xstat("DBSUB")
 	if err != nil {
@@ -138,6 +152,7 @@ func (s *ServerStatus) DoubleByteSubstitution() (bool, error) {
 	return utils.LastWordToBool(resp)
 }
 
+// DCBDSN returns the dataset whose DCB attributes model new allocations (XSTA DCBDSN).
 func (s *ServerStatus) DCBDSN() (string, error) {
 	resp, err := s.xstat("DCBDSN")
 	if err != nil {
@@ -146,6 +161,7 @@ func (s *ServerStatus) DCBDSN() (string, error) {
 	return utils.LastWord(resp), nil
 }
 
+// Destination returns the SYSOUT destination for jobs and reports (XSTA DEST).
 func (s *ServerStatus) Destination() (string, error) {
 	resp, err := s.xstat("DESt")
 	if err != nil {
@@ -154,6 +170,7 @@ func (s *ServerStatus) Destination() (string, error) {
 	return utils.LastWord(resp), nil
 }
 
+// Directory returns the number of directory blocks allocated for a new PDS (XSTA DIRECTORY).
 func (s *ServerStatus) Directory() (string, error) {
 	resp, err := s.xstat("Directory")
 	if err != nil {
@@ -162,6 +179,7 @@ func (s *ServerStatus) Directory() (string, error) {
 	return utils.RemoveNewLine(resp), nil
 }
 
+// DirectoryMode reports whether the server is in directory mode rather than dataset mode (XSTA DIRECTORYMODE).
 func (s *ServerStatus) DirectoryMode() (string, error) {
 	resp, err := s.xstat("DIRECTORYMode")
 	if err != nil {
@@ -170,6 +188,7 @@ func (s *ServerStatus) DirectoryMode() (string, error) {
 	return utils.RemoveNewLine(resp), nil
 }
 
+// DSNType returns the data-set name type (e.g. PDS, LIBRARY, BASIC) for new allocations (XSTA DSNTYPE).
 func (s *ServerStatus) DSNType() (string, error) {
 	resp, err := s.xstat("DSNTYPE")
 	if err != nil {
@@ -178,6 +197,7 @@ func (s *ServerStatus) DSNType() (string, error) {
 	return utils.LastWord(resp), nil
 }
 
+// DSWaitTime returns how long, in minutes, FTP waits for a held dataset before failing (XSTA DSWAITTIME).
 func (s *ServerStatus) DSWaitTime() (int, error) {
 	resp, err := s.xstat("DSWAITTIME")
 	if err != nil {
@@ -186,6 +206,7 @@ func (s *ServerStatus) DSWaitTime() (int, error) {
 	return utils.LastWordToInt(resp)
 }
 
+// EATTR returns the extended-attributes setting for new dataset allocation (XSTA EATTR).
 func (s *ServerStatus) EATTR() (string, error) {
 	resp, err := s.xstat("EATTR")
 	if err != nil {
@@ -194,6 +215,7 @@ func (s *ServerStatus) EATTR() (string, error) {
 	return utils.LastWord(resp), nil
 }
 
+// Encoding returns the encoding (SBCS or MBCS) used for the data connection (XSTA ENCODING).
 func (s *ServerStatus) Encoding() (string, error) {
 	resp, err := s.xstat("ENCODING")
 	if err != nil {
@@ -202,6 +224,7 @@ func (s *ServerStatus) Encoding() (string, error) {
 	return utils.LastWord(resp), nil
 }
 
+// FifoIoTime returns the time-out, in seconds, for a single read/write on a z/OS FIFO (XSTA FIFOIOTIME).
 func (s *ServerStatus) FifoIoTime() (int, error) {
 	resp, err := s.xstat("FIFOIOTIME")
 	if err != nil {
@@ -210,6 +233,7 @@ func (s *ServerStatus) FifoIoTime() (int, error) {
 	return utils.LastWordToInt(resp)
 }
 
+// FifoOpenTime returns the time-out, in seconds, for opening a z/OS FIFO (XSTA FIFOOPENTIME).
 func (s *ServerStatus) FifoOpenTime() (int, error) {
 	resp, err := s.xstat("FIFOOPENTIME")
 	if err != nil {
@@ -218,6 +242,7 @@ func (s *ServerStatus) FifoOpenTime() (int, error) {
 	return utils.LastWordToInt(resp)
 }
 
+// FileType returns the current file type — SEQ, JES, or SQL (XSTA FILETYPE).
 func (s *ServerStatus) FileType() (string, error) {
 	resp, err := s.xstat("FileType")
 	if err != nil {
@@ -231,6 +256,7 @@ func (s *ServerStatus) FileType() (string, error) {
 	return ft[1], nil
 }
 
+// FTPKeepAlive returns the control-connection TCP keep-alive interval, in seconds (XSTA FTPKEEPALIVE).
 func (s *ServerStatus) FTPKeepAlive() (int, error) {
 	resp, err := s.xstat("FTpkeepalive")
 	if err != nil {
@@ -239,6 +265,7 @@ func (s *ServerStatus) FTPKeepAlive() (int, error) {
 	return utils.LastWordToInt(resp)
 }
 
+// InactiveTime returns the inactivity time-out, in seconds, before the session is closed (XSTA INACTIVETIME).
 func (s *ServerStatus) InactiveTime() (int, error) {
 	resp, err := s.xstat("INactivetime")
 	if err != nil {
@@ -247,6 +274,7 @@ func (s *ServerStatus) InactiveTime() (int, error) {
 	return utils.LastWordToInt(resp)
 }
 
+// ISPFStats reports whether ISPF statistics are maintained for PDS members (XSTA ISPFSTATS).
 func (s *ServerStatus) ISPFStats() (bool, error) {
 	resp, err := s.xstat("ISPFSTATS")
 	if err != nil {
@@ -255,6 +283,7 @@ func (s *ServerStatus) ISPFStats() (bool, error) {
 	return utils.LastWordToBool(resp)
 }
 
+// JesEntryLimit returns the maximum number of JES entries a query may return (XSTA JESENTRYLIMIT).
 func (s *ServerStatus) JesEntryLimit() (int, error) {
 	resp, err := s.xstat("JESENTRYLimit")
 	if err != nil {
@@ -263,6 +292,7 @@ func (s *ServerStatus) JesEntryLimit() (int, error) {
 	return utils.LastWordToInt(resp)
 }
 
+// JesGetByDSN reports whether retrieving a job's output by DSN is enabled (XSTA JESGETBYDSN).
 func (s *ServerStatus) JesGetByDSN() (bool, error) {
 	resp, err := s.xstat("JESGETBYDSN")
 	if err != nil {
@@ -271,6 +301,7 @@ func (s *ServerStatus) JesGetByDSN() (bool, error) {
 	return utils.LastWordToBool(resp)
 }
 
+// JesJobName returns the job-name filter applied to JES queries (XSTA JESJOBNAME).
 func (s *ServerStatus) JesJobName() (string, error) {
 	resp, err := s.xstat("JESJOBName")
 	if err != nil {
@@ -279,6 +310,7 @@ func (s *ServerStatus) JesJobName() (string, error) {
 	return utils.LastText(resp), nil
 }
 
+// JesLrecl returns the record length used for jobs submitted to the internal reader (XSTA JESLRECL).
 func (s *ServerStatus) JesLrecl() (int, error) {
 	resp, err := s.xstat("JESLrecl")
 	if err != nil {
@@ -287,6 +319,7 @@ func (s *ServerStatus) JesLrecl() (int, error) {
 	return utils.LastWordToInt(resp)
 }
 
+// JesOwner returns the owner filter applied to JES queries (XSTA JESOWNER).
 func (s *ServerStatus) JesOwner() (string, error) {
 	resp, err := s.xstat("JESOwner")
 	if err != nil {
@@ -295,6 +328,7 @@ func (s *ServerStatus) JesOwner() (string, error) {
 	return utils.LastWord(resp), nil
 }
 
+// JesRecfm returns the record format used for jobs submitted to the internal reader (XSTA JESRECFM).
 func (s *ServerStatus) JesRecfm() (string, error) {
 	resp, err := s.xstat("JESRecfm")
 	if err != nil {
@@ -303,6 +337,7 @@ func (s *ServerStatus) JesRecfm() (string, error) {
 	return utils.LastWord(resp), nil
 }
 
+// JesStatus returns the job-status filter applied to JES queries (XSTA JESSTATUS).
 func (s *ServerStatus) JesStatus() (string, error) {
 	resp, err := s.xstat("JESSTatus")
 	if err != nil {
@@ -311,6 +346,7 @@ func (s *ServerStatus) JesStatus() (string, error) {
 	return utils.LastText(resp), nil
 }
 
+// ListLevel returns the LISTLEVEL controlling the column layout of dataset listings (XSTA LISTLEVEL).
 func (s *ServerStatus) ListLevel() (int, error) {
 	resp, err := s.xstat("LISTLEVEL")
 	if err != nil {
@@ -319,6 +355,7 @@ func (s *ServerStatus) ListLevel() (int, error) {
 	return utils.LastWordToInt(resp)
 }
 
+// ListSubDir reports whether LIST recurses into HFS subdirectories (XSTA LISTSUBDIR).
 func (s *ServerStatus) ListSubDir() (bool, error) {
 	resp, err := s.xstat("LISTSUBdir")
 	if err != nil {
@@ -327,6 +364,7 @@ func (s *ServerStatus) ListSubDir() (bool, error) {
 	return utils.LastWordToBool(resp)
 }
 
+// Lrecl returns the logical record length (LRECL) from the record-format status line (XSTA LRECL).
 func (s *ServerStatus) Lrecl() (int, error) {
 	resp, err := s.xstat("Lrecl")
 	if err != nil {
@@ -340,6 +378,7 @@ func (s *ServerStatus) Lrecl() (int, error) {
 	return strconv.Atoi(m[2])
 }
 
+// MBDataConn returns the multibyte data-connection codepage pair (network, host) (XSTA MBDATACONN).
 func (s *ServerStatus) MBDataConn() (string, error) {
 	resp, err := s.xstat("MBDATACONN")
 	if err != nil {
@@ -348,6 +387,7 @@ func (s *ServerStatus) MBDataConn() (string, error) {
 	return utils.LastWord(resp), nil
 }
 
+// MBRequireLastEol reports whether a final end-of-line is required on inbound multibyte data (XSTA MBREQUIRELASTEOL).
 func (s *ServerStatus) MBRequireLastEol() (bool, error) {
 	resp, err := s.xstat("MBREQUIRELASTEOL")
 	if err != nil {
@@ -358,6 +398,7 @@ func (s *ServerStatus) MBRequireLastEol() (bool, error) {
 
 var eolFmt = regexp.MustCompile(`uses\s+(\w+)\s+line\s+terminator$`)
 
+// MBSendEol returns the end-of-line sequence appended to outbound multibyte data (XSTA MBSENDEOL).
 func (s *ServerStatus) MBSendEol() (string, error) {
 	resp, err := s.xstat("MBSENDEOL")
 	if err != nil {
@@ -370,6 +411,7 @@ func (s *ServerStatus) MBSendEol() (string, error) {
 	return m[1], nil
 }
 
+// MgmtClass returns the SMS management class used for new dataset allocation (XSTA MGMTCLASS).
 func (s *ServerStatus) MgmtClass() (string, error) {
 	resp, err := s.xstat("MGmtclass")
 	if err != nil {
@@ -378,6 +420,7 @@ func (s *ServerStatus) MgmtClass() (string, error) {
 	return utils.LastWord(resp), nil
 }
 
+// MigrateVol returns the volume serial reported for a migrated dataset (XSTA MIGRATEVOL).
 func (s *ServerStatus) MigrateVol() (string, error) {
 	resp, err := s.xstat("MIGratevol")
 	if err != nil {
@@ -386,6 +429,7 @@ func (s *ServerStatus) MigrateVol() (string, error) {
 	return utils.LastWord(resp), nil
 }
 
+// PDSType reports whether new partitioned datasets are created as PDS or PDSE (XSTA PDSTYPE).
 func (s *ServerStatus) PDSType() (string, error) {
 	resp, err := s.xstat("PDSTYPE")
 	if err != nil {
@@ -394,6 +438,7 @@ func (s *ServerStatus) PDSType() (string, error) {
 	return utils.RemoveNewLine(resp), nil
 }
 
+// Primary returns the primary space allocation for new datasets (XSTA PRIMARY).
 func (s *ServerStatus) Primary() (string, error) {
 	resp, err := s.xstat("Primary")
 	if err != nil {
@@ -402,6 +447,7 @@ func (s *ServerStatus) Primary() (string, error) {
 	return utils.RemoveNewLine(resp), nil
 }
 
+// QuotesOverride reports whether a leading quote overrides the working-directory prefix (XSTA QUOTESOVERRIDE).
 func (s *ServerStatus) QuotesOverride() (string, error) {
 	resp, err := s.xstat("QUOtesoverride")
 	if err != nil {
@@ -410,6 +456,7 @@ func (s *ServerStatus) QuotesOverride() (string, error) {
 	return utils.RemoveNewLine(resp), nil
 }
 
+// RDW reports whether variable-record descriptor words are retained as data (XSTA RDW).
 func (s *ServerStatus) RDW() (string, error) {
 	resp, err := s.xstat("RDW")
 	if err != nil {
@@ -418,6 +465,7 @@ func (s *ServerStatus) RDW() (string, error) {
 	return utils.RemoveNewLine(resp), nil
 }
 
+// ReadTapeFormat returns the record format used when reading a tape dataset (XSTA READTAPEFORMAT).
 func (s *ServerStatus) ReadTapeFormat() (string, error) {
 	resp, err := s.xstat("READTAPEFormat")
 	if err != nil {
@@ -426,6 +474,7 @@ func (s *ServerStatus) ReadTapeFormat() (string, error) {
 	return utils.RemoveNewLine(resp), nil
 }
 
+// Recfm returns the record format (RECFM) from the record-format status line (XSTA RECFM).
 func (s *ServerStatus) Recfm() (string, error) {
 	resp, err := s.xstat("Recfm")
 	if err != nil {
@@ -438,6 +487,7 @@ func (s *ServerStatus) Recfm() (string, error) {
 	return m[1], nil
 }
 
+// RetPD returns the retention period, in days, for new datasets (XSTA RETPD).
 func (s *ServerStatus) RetPD() (int, error) {
 	resp, err := s.xstat("RetPD")
 	if err != nil {
@@ -457,6 +507,7 @@ func (s *ServerStatus) SBDataConn() (string, error) {
 	return utils.LastWord(resp), nil
 }
 
+// SBSendEol returns the end-of-line sequence appended to outbound single-byte data (XSTA SBSENDEOL).
 func (s *ServerStatus) SBSendEol() (string, error) {
 	resp, err := s.xstat("SBSENDEOL")
 	if err != nil {
@@ -469,6 +520,7 @@ func (s *ServerStatus) SBSendEol() (string, error) {
 	return m[1], nil
 }
 
+// SBSub reports whether single-byte substitution is enabled (XSTA SBSUB).
 func (s *ServerStatus) SBSub() (bool, error) {
 	resp, err := s.xstat("SBSUB")
 	if err != nil {
@@ -477,6 +529,7 @@ func (s *ServerStatus) SBSub() (bool, error) {
 	return utils.LastWordToBool(resp)
 }
 
+// SBSubChar returns the substitution character used for untranslatable single-byte data (XSTA SBSUBCHAR).
 func (s *ServerStatus) SBSubChar() (string, error) {
 	resp, err := s.xstat("SBSUBCHAR")
 	if err != nil {
@@ -485,6 +538,7 @@ func (s *ServerStatus) SBSubChar() (string, error) {
 	return utils.LastWord(resp), nil
 }
 
+// Secondary returns the secondary space allocation for new datasets (XSTA SECONDARY).
 func (s *ServerStatus) Secondary() (string, error) {
 	resp, err := s.xstat("SECondary")
 	if err != nil {
@@ -493,6 +547,7 @@ func (s *ServerStatus) Secondary() (string, error) {
 	return utils.RemoveNewLine(resp), nil
 }
 
+// SPRead returns the SPREAD setting controlling multi-volume primary allocation (XSTA SPREAD).
 func (s *ServerStatus) SPRead() (string, error) {
 	resp, err := s.xstat("SPRead")
 	if err != nil {
@@ -501,6 +556,7 @@ func (s *ServerStatus) SPRead() (string, error) {
 	return utils.RemoveNewLine(resp), nil
 }
 
+// SQLCol returns the SQL column-naming setting for query output (XSTA SQLCOL).
 func (s *ServerStatus) SQLCol() (string, error) {
 	resp, err := s.xstat("SQLCol")
 	if err != nil {
@@ -509,6 +565,7 @@ func (s *ServerStatus) SQLCol() (string, error) {
 	return utils.LastWord(resp), nil
 }
 
+// StorageClass returns the SMS storage class used for new dataset allocation (XSTA STORCLASS).
 func (s *ServerStatus) StorageClass() (string, error) {
 	resp, err := s.xstat("STOrclass")
 	if err != nil {
@@ -517,6 +574,7 @@ func (s *ServerStatus) StorageClass() (string, error) {
 	return utils.LastWord(resp), nil
 }
 
+// TlsRfcLevel returns the level of RFC 4217 (FTP-over-TLS) support reported (XSTA TLSRFCLEVEL).
 func (s *ServerStatus) TlsRfcLevel() (string, error) {
 	resp, err := s.xstat("TLSRFCLEVEL")
 	if err != nil {
@@ -525,6 +583,7 @@ func (s *ServerStatus) TlsRfcLevel() (string, error) {
 	return utils.RemoveNewLine(resp), nil
 }
 
+// Tracks reports whether primary/secondary space is allocated in tracks (XSTA TRACKS).
 func (s *ServerStatus) Tracks() (string, error) {
 	resp, err := s.xstat("TRacks")
 	if err != nil {
@@ -533,6 +592,7 @@ func (s *ServerStatus) Tracks() (string, error) {
 	return utils.RemoveNewLine(resp), nil
 }
 
+// TrailingBlanks reports whether trailing blanks in fixed-length records are preserved (XSTA TRAILINGBLANKS).
 func (s *ServerStatus) TrailingBlanks() (string, error) {
 	resp, err := s.xstat("TRAILingblanks")
 	if err != nil {
@@ -541,6 +601,7 @@ func (s *ServerStatus) TrailingBlanks() (string, error) {
 	return utils.RemoveNewLine(resp), nil
 }
 
+// Truncate reports whether records longer than LRECL are truncated rather than failing (XSTA TRUNCATE).
 func (s *ServerStatus) Truncate() (string, error) {
 	resp, err := s.xstat("TRUNcate")
 	if err != nil {
@@ -549,6 +610,7 @@ func (s *ServerStatus) Truncate() (string, error) {
 	return utils.RemoveNewLine(resp), nil
 }
 
+// UCount returns the number of devices (unit count) for a new allocation (XSTA UCOUNT).
 func (s *ServerStatus) UCount() (int, error) {
 	resp, err := s.xstat("UCOUNT")
 	if err != nil {
@@ -557,6 +619,7 @@ func (s *ServerStatus) UCount() (int, error) {
 	return utils.LastWordToInt(resp)
 }
 
+// UCSHostCS returns the host character set used for Unicode conversion (XSTA UCSHOSTCS).
 func (s *ServerStatus) UCSHostCS() (string, error) {
 	resp, err := s.xstat("UCSHOSTCS")
 	if err != nil {
@@ -565,6 +628,7 @@ func (s *ServerStatus) UCSHostCS() (string, error) {
 	return utils.RemoveNewLine(resp), nil
 }
 
+// UCSSub reports whether substitution is used for untranslatable Unicode characters (XSTA UCSSUB).
 func (s *ServerStatus) UCSSub() (string, error) {
 	resp, err := s.xstat("UCSSUB")
 	if err != nil {
@@ -573,6 +637,7 @@ func (s *ServerStatus) UCSSub() (string, error) {
 	return utils.LastWord(resp), nil
 }
 
+// UCSTrunc reports whether Unicode data is truncated on a conversion error (XSTA UCSTRUNC).
 func (s *ServerStatus) UCSTrunc() (string, error) {
 	resp, err := s.xstat("UCSTRUNC")
 	if err != nil {
@@ -597,6 +662,7 @@ func (s *ServerStatus) UMask() (int, error) {
 	return int(n), nil
 }
 
+// UnicodeFileSystemBOM reports whether a byte-order mark is written to Unicode HFS files (XSTA UNICODEFILESYSTEMBOM).
 func (s *ServerStatus) UnicodeFileSystemBOM() (string, error) {
 	resp, err := s.xstat("UNICODEFILESYSTEMBOM")
 	if err != nil {
@@ -605,6 +671,7 @@ func (s *ServerStatus) UnicodeFileSystemBOM() (string, error) {
 	return utils.LastWord(resp), nil
 }
 
+// Unit returns the device unit used for new dataset allocation (XSTA UNIT).
 func (s *ServerStatus) Unit() (string, error) {
 	resp, err := s.xstat("Unit")
 	if err != nil {
@@ -613,6 +680,7 @@ func (s *ServerStatus) Unit() (string, error) {
 	return utils.LastWord(resp), nil
 }
 
+// UnixFileType returns the HFS file type (regular file or FIFO) used for transfers (XSTA UNIXFILETYPE).
 func (s *ServerStatus) UnixFileType() (string, error) {
 	resp, err := s.xstat("UNIXFILETYPE")
 	if err != nil {
@@ -621,6 +689,7 @@ func (s *ServerStatus) UnixFileType() (string, error) {
 	return utils.LastWord(resp), nil
 }
 
+// VCount returns the number of volumes (volume count) for a new allocation (XSTA VCOUNT).
 func (s *ServerStatus) VCount() (int, error) {
 	resp, err := s.xstat("VCOUNT")
 	if err != nil {
@@ -629,6 +698,7 @@ func (s *ServerStatus) VCount() (int, error) {
 	return utils.LastWordToInt(resp)
 }
 
+// Volume returns the volume serial used for new dataset allocation (XSTA VOLUME).
 func (s *ServerStatus) Volume() (string, error) {
 	resp, err := s.xstat("VOLume")
 	if err != nil {
@@ -637,6 +707,7 @@ func (s *ServerStatus) Volume() (string, error) {
 	return utils.LastWord(resp), nil
 }
 
+// WrapRecord reports whether data is wrapped to the next record instead of truncated (XSTA WRAPRECORD).
 func (s *ServerStatus) WrapRecord() (string, error) {
 	resp, err := s.xstat("WRAPrecord")
 	if err != nil {
@@ -645,6 +716,7 @@ func (s *ServerStatus) WrapRecord() (string, error) {
 	return utils.RemoveNewLine(resp), nil
 }
 
+// WRTapeFastIo reports whether fast (BSAM) I/O is used when writing tape (XSTA WRTAPEFASTIO).
 func (s *ServerStatus) WRTapeFastIo() (string, error) {
 	resp, err := s.xstat("WRTAPEFastio")
 	if err != nil {
@@ -653,6 +725,7 @@ func (s *ServerStatus) WRTapeFastIo() (string, error) {
 	return utils.RemoveNewLine(resp), nil
 }
 
+// XLate returns the translate-table name used for the data connection (XSTA XLATE).
 func (s *ServerStatus) XLate() (string, error) {
 	resp, err := s.xstat("XLate")
 	if err != nil {

--- a/status_set.go
+++ b/status_set.go
@@ -36,6 +36,8 @@ func (s *StatusSetter) FileType(Type string) error {
 	return err
 }
 
+// JesEntryLimit sets the maximum number of JES entries a query may return (SITE
+// JESENTRYLIMIT). The valid range is 0 to 1024.
 func (s *StatusSetter) JesEntryLimit(limit int) error {
 	if limit < 0 || limit > 1024 {
 		return fmt.Errorf("JesEntryLimit must be between 0 and 1024")
@@ -45,6 +47,8 @@ func (s *StatusSetter) JesEntryLimit(limit int) error {
 	return err
 }
 
+// JesGetByDSN enables or disables retrieving a job's output by DSN (SITE
+// JESGETBYDSN / NOJESGETBYDSN).
 func (s *StatusSetter) JesGetByDSN(option bool) error {
 	cmd := "NOJESGETBYDSN"
 	if option {
@@ -55,6 +59,8 @@ func (s *StatusSetter) JesGetByDSN(option bool) error {
 	return err
 }
 
+// JesJobName sets the job-name filter applied to JES queries (SITE JESJOBNAME);
+// "*" matches every job name.
 func (s *StatusSetter) JesJobName(expression string) error {
 	_, err := s.site(fmt.Sprintf("JESJOBNAME=%s", expression))
 	return err
@@ -94,11 +100,16 @@ func (s *StatusSetter) JesPutGetTimeOut(seconds int) error {
 	return err
 }
 
+// JesOwner sets the owner filter applied to JES queries (SITE JESOWNER); "*"
+// matches every owner.
 func (s *StatusSetter) JesOwner(expression string) error {
 	_, err := s.site(fmt.Sprintf("JESOWNER=%s", expression))
 	return err
 }
 
+// JesStatus sets the job-status filter applied to JES queries (SITE JESSTATUS).
+// Valid values are ALL, ACTIVE, OUTPUT, INPUT, EXECUTION, JOBLOG, JOBMSG, and
+// JOBSTATUS.
 func (s *StatusSetter) JesStatus(expression string) error {
 	switch expression {
 	case "ALL", "ACTIVE", "OUTPUT", "INPUT", "EXECUTION", "JOBLOG", "JOBMSG", "JOBSTATUS":
@@ -110,16 +121,22 @@ func (s *StatusSetter) JesStatus(expression string) error {
 	return err
 }
 
+// ListLevel sets the LISTLEVEL that controls the column layout of dataset
+// listings (SITE LISTLEVEL).
 func (s *StatusSetter) ListLevel(level int) error {
 	_, err := s.site(fmt.Sprintf("LISTLEVEL=%d", level))
 	return err
 }
 
+// SBSendEol sets the end-of-line sequence appended to outbound single-byte data
+// (SITE SBSENDEOL).
 func (s *StatusSetter) SBSendEol(eol eol.LineBreaker) error {
 	_, err := s.site(fmt.Sprintf("SBSENDEOL=%s", eol.String()))
 	return err
 }
 
+// MBSendEol sets the end-of-line sequence appended to outbound multibyte data
+// (SITE MBSENDEOL).
 func (s *StatusSetter) MBSendEol(eol eol.LineBreaker) error {
 	_, err := s.site(fmt.Sprintf("MBSENDEOL=%s", eol.String()))
 	return err

--- a/transfer.go
+++ b/transfer.go
@@ -146,11 +146,15 @@ func (s *FTPSession) transfer(t transfer.DataTransfer, remote string, offset int
 // stack emit an RST. It closes the data connection and reads the terminal reply on
 // the control connection; that read is timeout-bounded by checkLast because z/OS
 // sends the reply asynchronously to the data close and it can be lost.
+//
+// The transfer is complete on either 250 (CodeFileActionOK) or 226
+// (CodeClosingDataConn): RFC 959 and the z/OS FTP dialect both allow either to
+// close a successful RETR/STOR/LIST, so checkLast accepts both.
 func (s *FTPSession) confirmData(child *childConnection) (string, error) {
 	if err := child.Close(); err != nil {
 		return "", err
 	}
-	return s.checkLast(CodeFileActionOK)
+	return s.checkLast(CodeFileActionOK, CodeClosingDataConn)
 }
 
 // restoreType puts the session back to a prior transfer type and is meant to be


### PR DESCRIPTION
Final P2 hardening batch before the CLI work. Three strict-TDD commits (RED → GREEN, `go test -race ./...` after each); ZH17 was already satisfied on `main` and closed separately.

Closes #72, closes #73, closes #74.

## ZH18 — cover untested critical paths (#72)
AuthTLS, JES, GetAndGzip and binary-offset resume had no real assertions (only env-gated skips against a live LPAR). Extended `internal/mockzos` and added black-box tests:
- **mockzos**: `EnableTLS` upgrades the control connection to an in-process TLS server on `AUTH TLS`; `CompletionReply` overrides the post-transfer closing reply per verb (to carry a JES job id or a 226/250 code). The per-connection reader moved into `session` so the AUTH TLS conn/reader swap is seen by later commands.
- **AuthTLS**: full `AUTH TLS → PBSZ/PROT → login → command`, all over TLS, with a self-signed loopback certificate.
- **JES**: `SubmitJCL` job-id extraction; `GetJobStatus` level-2 parse + return code; `SubmitJesGetByDSN` success (RC parse), plus IEF and ABEND classification.
- **GetAndGzip**: round-trip a payload; assert the `.gz` decompresses to the original (exercises `VerifyGzSize`).
- **Offset**: binary `GetAt` writes retrieved bytes at the local offset (`REST <n>`); binary `PutAt` uploads from the source offset.

## ZH19 — godoc for the public surface (#73)
One-line doc on every previously-undocumented exported identifier: the ~72 `ServerStatus` XSTA getters, the 8 `StatusSetter` SITE setters, `JobResult`/`JesSpec`/`Recfm`/`JesJob` fields, the block-size bounds, and a group comment for the FTP reply codes. A new `doc_coverage_test.go` parses the package source and fails if any exported identifier lacks documentation (trailing comment or documented block counts; generated files skipped), so the surface cannot regress.

**Breaking (v2, untagged):** `JesOptionFunc` is now unexported — it was only the adapter behind the `With…` constructors, which remain the supported way to build a `JesSpec`.

## ZH20 — accept 226-or-250 completion + gzip polish (#74)
- The post-transfer reply read accepted only 250, leaving 226 (`CodeClosingDataConn`) defined-but-unused; RFC 959 / z/OS allow either to close a successful RETR/STOR/LIST. `checkLast` now takes alternate accepted codes and `confirmData` passes 226 alongside 250; a genuinely unexpected reply still surfaces as a `*ReturnError` with the stream in sync. Tests assert 226 acceptance on RETR/STOR/LIST (RED before the fix); 250 stays green.
- gzip: dropped the redundant `Flush` before `Close` in `GetAndGzip`; documented that `VerifyGzSize` is only meaningful below 4 GiB (gzip ISIZE is size mod 2^32).

## Gate
`CGO_ENABLED=0 go build`, `go vet`, `staticcheck`, `go test -race ./...`, `govulncheck` (no vulnerabilities), `cd cli && go build` — all green locally.