### PR TITLE
feat: library session mutation methods (Delete/Mkdir/Rename/Chmod/PurgeJob)

### DIFF
--- a/internal/mockzos/server.go
+++ b/internal/mockzos/server.go
@@ -188,6 +188,14 @@ func (s *Server) dispatch(sess *session, line, verb, arg string) bool {
 		writeLines(sess.conn, []string{"350 restarting at the requested offset, send transfer command"})
 	case "CWD":
 		writeLines(sess.conn, []string{"250 directory changed"})
+	case "DELE":
+		writeLines(sess.conn, []string{"250 file deleted"})
+	case "MKD", "XMKD":
+		writeLines(sess.conn, []string{fmt.Sprintf("257 %q directory created", arg)})
+	case "RNFR":
+		writeLines(sess.conn, []string{"350 file exists, ready for destination name"})
+	case "RNTO":
+		writeLines(sess.conn, []string{"250 rename successful"})
 	case "NOOP":
 		writeLines(sess.conn, []string{"200 command okay"})
 	case "PASV":

--- a/jes.go
+++ b/jes.go
@@ -327,3 +327,16 @@ type jesOptionFunc func(*FTPSession) error
 func (f jesOptionFunc) Apply(s *FTPSession) error {
 	return f(s)
 }
+
+// PurgeJob deletes a job from the JES spool by job id (DELE under FILETYPE=JES).
+// The session's file type is set to JES for the call and restored afterward. A
+// 550 (unknown job / not owner) is returned as a *ReturnError.
+func (s *FTPSession) PurgeJob(jobID string) error {
+	ft, err := utils.SetValueAndGetCurrent(s.log, "JES", s.SetStatusOf().FileType, s.StatusOf().FileType)
+	if err != nil {
+		return err
+	}
+	defer ft.Restore()
+	_, err = s.SendCommand(CodeFileActionOK, "DELE", jobID)
+	return err
+}

--- a/jes_test.go
+++ b/jes_test.go
@@ -206,3 +206,38 @@ $$DITTO TLB INPUT=TAPEIN
 	t.Logf("Expected Error: %s", err)
 	t.Logf("Spool:\n%s", strings.Join(job.Spool, "\n")) // Print the spool
 }
+
+func TestPurgeJob_OK(t *testing.T) {
+	s, srv := dialMock(t)
+	srv.Script("DELE", "250 job JOB12345 purged")
+	if err := s.PurgeJob("JOB12345"); err != nil {
+		t.Fatalf("PurgeJob: %v", err)
+	}
+	cmds := srv.Commands()
+	var idxSite, idxDele int = -1, -1
+	for i, c := range cmds {
+		if c == "SITE FILETYPE=JES" {
+			idxSite = i
+		}
+		if c == "DELE JOB12345" {
+			idxDele = i
+		}
+	}
+	if idxSite < 0 {
+		t.Fatalf("missing SITE FILETYPE=JES in %v", cmds)
+	}
+	if idxDele < 0 {
+		t.Fatalf("missing DELE JOB12345 in %v", cmds)
+	}
+	if idxSite >= idxDele {
+		t.Fatalf("SITE FILETYPE=JES must appear before DELE JOB12345; got %v", cmds)
+	}
+}
+
+func TestPurgeJob_Error(t *testing.T) {
+	s, srv := dialMock(t)
+	srv.Script("DELE", "550 job not found")
+	if err := s.PurgeJob("JOB12345"); !errors.Is(err, zftp.CodeError(550)) {
+		t.Fatalf("PurgeJob err = %v, want CodeError(550)", err)
+	}
+}

--- a/mutations.go
+++ b/mutations.go
@@ -20,6 +20,13 @@ func (s *FTPSession) Mkdir(path string) error {
 	return err
 }
 
+// Chmod changes HFS file permissions via SITE CHMOD <mode> <path>. mode is an
+// octal string ("750"). It is meaningful only for z/OS UNIX (HFS) files.
+func (s *FTPSession) Chmod(mode, path string) error {
+	_, err := s.Site("CHMOD", mode, path)
+	return err
+}
+
 // Rename renames a file or dataset from -> to using the RNFR/RNTO sequence. The
 // two round-trips are issued under a single hold of the session mutex so no other
 // goroutine's command can interleave between them, keeping *FTPSession safe to

--- a/mutations.go
+++ b/mutations.go
@@ -2,6 +2,8 @@
 
 package zftp
 
+import "context"
+
 // Delete removes a file or dataset on the server with a DELE command. name is the
 // HFS path or a quoted dataset name ('USER.DATA'). A 550 (not found / not
 // permitted) is returned as a *ReturnError; match it with errors.Is(err, CodeError(550)).
@@ -15,5 +17,20 @@ func (s *FTPSession) Delete(name string) error {
 // *ReturnError.
 func (s *FTPSession) Mkdir(path string) error {
 	_, err := s.SendCommand(CodeDirCreated, "MKD", path)
+	return err
+}
+
+// Rename renames a file or dataset from -> to using the RNFR/RNTO sequence. The
+// two round-trips are issued under a single hold of the session mutex so no other
+// goroutine's command can interleave between them, keeping *FTPSession safe to
+// share across goroutines. A failing RNFR (e.g. 550) is returned without sending
+// RNTO.
+func (s *FTPSession) Rename(from, to string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, err := s.sendLocked(context.Background(), CodeNeedInfo, "RNFR", from); err != nil {
+		return err
+	}
+	_, err := s.sendLocked(context.Background(), CodeFileActionOK, "RNTO", to)
 	return err
 }

--- a/mutations.go
+++ b/mutations.go
@@ -9,3 +9,11 @@ func (s *FTPSession) Delete(name string) error {
 	_, err := s.SendCommand(CodeFileActionOK, "DELE", name)
 	return err
 }
+
+// Mkdir creates a directory on the server with an MKD command (HFS directory or,
+// under SITE DIRECTORYMODE, a dataset qualifier). A 550 is returned as a
+// *ReturnError.
+func (s *FTPSession) Mkdir(path string) error {
+	_, err := s.SendCommand(CodeDirCreated, "MKD", path)
+	return err
+}

--- a/mutations.go
+++ b/mutations.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package zftp
+
+// Delete removes a file or dataset on the server with a DELE command. name is the
+// HFS path or a quoted dataset name ('USER.DATA'). A 550 (not found / not
+// permitted) is returned as a *ReturnError; match it with errors.Is(err, CodeError(550)).
+func (s *FTPSession) Delete(name string) error {
+	_, err := s.SendCommand(CodeFileActionOK, "DELE", name)
+	return err
+}

--- a/mutations_test.go
+++ b/mutations_test.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+package zftp_test
+
+import (
+	"errors"
+	"testing"
+
+	"gopkg.in/ro-ag/zftp.v2"
+)
+
+func TestDelete_OK(t *testing.T) {
+	s, _ := dialMock(t)
+	if err := s.Delete("'USER.OLD.DATA'"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+}
+
+func TestDelete_ServerError(t *testing.T) {
+	s, srv := dialMock(t)
+	srv.Script("DELE", "550 dataset not found")
+	err := s.Delete("'USER.NOPE'")
+	if !errors.Is(err, zftp.CodeError(550)) {
+		t.Fatalf("Delete err = %v, want CodeError(550)", err)
+	}
+}

--- a/mutations_test.go
+++ b/mutations_test.go
@@ -23,3 +23,19 @@ func TestDelete_ServerError(t *testing.T) {
 		t.Fatalf("Delete err = %v, want CodeError(550)", err)
 	}
 }
+
+func TestMkdir_OK(t *testing.T) {
+	s, _ := dialMock(t)
+	if err := s.Mkdir("/u/user/newdir"); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+}
+
+func TestMkdir_ServerError(t *testing.T) {
+	s, srv := dialMock(t)
+	srv.Script("MKD", "550 permission denied")
+	err := s.Mkdir("/u/user/newdir")
+	if !errors.Is(err, zftp.CodeError(550)) {
+		t.Fatalf("Mkdir err = %v, want CodeError(550)", err)
+	}
+}

--- a/mutations_test.go
+++ b/mutations_test.go
@@ -3,6 +3,7 @@ package zftp_test
 
 import (
 	"errors"
+	"sync"
 	"testing"
 
 	"gopkg.in/ro-ag/zftp.v2"
@@ -37,5 +38,57 @@ func TestMkdir_ServerError(t *testing.T) {
 	err := s.Mkdir("/u/user/newdir")
 	if !errors.Is(err, zftp.CodeError(550)) {
 		t.Fatalf("Mkdir err = %v, want CodeError(550)", err)
+	}
+}
+
+func TestRename_OK(t *testing.T) {
+	s, srv := dialMock(t)
+	if err := s.Rename("'USER.A'", "'USER.B'"); err != nil {
+		t.Fatalf("Rename: %v", err)
+	}
+	cmds := srv.Commands()
+	var sawFR, sawTO bool
+	for i, c := range cmds {
+		if c == "RNFR 'USER.A'" {
+			sawFR = true
+			if i+1 >= len(cmds) || cmds[i+1] != "RNTO 'USER.B'" {
+				t.Fatalf("RNTO must immediately follow RNFR; got %v", cmds)
+			}
+		}
+		if c == "RNTO 'USER.B'" {
+			sawTO = true
+		}
+	}
+	if !sawFR || !sawTO {
+		t.Fatalf("missing RNFR/RNTO in %v", cmds)
+	}
+}
+
+func TestRename_RNFRError(t *testing.T) {
+	s, srv := dialMock(t)
+	srv.Script("RNFR", "550 source not found")
+	if err := s.Rename("'USER.NOPE'", "'USER.B'"); !errors.Is(err, zftp.CodeError(550)) {
+		t.Fatalf("Rename err = %v, want CodeError(550)", err)
+	}
+}
+
+// TestRename_NoInterleave runs many concurrent Renames + SendCommands under -race
+// and asserts every RNTO immediately follows its RNFR (the pair never splits).
+func TestRename_NoInterleave(t *testing.T) {
+	s, srv := dialMock(t)
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(2)
+		go func() { defer wg.Done(); _ = s.Rename("'A'", "'B'") }()
+		go func() { defer wg.Done(); _, _ = s.SendCommand(zftp.CodeCmdOK, "NOOP") }()
+	}
+	wg.Wait()
+	cmds := srv.Commands()
+	for i, c := range cmds {
+		if c == "RNFR 'A'" {
+			if i+1 >= len(cmds) || cmds[i+1] != "RNTO 'B'" {
+				t.Fatalf("RNFR/RNTO split by a concurrent command at %d: %v", i, cmds)
+			}
+		}
 	}
 }

--- a/mutations_test.go
+++ b/mutations_test.go
@@ -92,3 +92,26 @@ func TestRename_NoInterleave(t *testing.T) {
 		}
 	}
 }
+
+func TestChmod_OK(t *testing.T) {
+	s, srv := dialMock(t)
+	if err := s.Chmod("750", "/u/user/file"); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+	cmds := srv.Commands()
+	want := "SITE CHMOD 750 /u/user/file"
+	for _, c := range cmds {
+		if c == want {
+			return
+		}
+	}
+	t.Fatalf("missing %q in %v", want, cmds)
+}
+
+func TestChmod_ServerError(t *testing.T) {
+	s, srv := dialMock(t)
+	srv.Script("SITE", "550 not permitted")
+	if err := s.Chmod("750", "/u/user/file"); !errors.Is(err, zftp.CodeError(550)) {
+		t.Fatalf("Chmod err = %v, want CodeError(550)", err)
+	}
+}


### PR DESCRIPTION
Closes #77

Adds the missing server-mutation methods to the v2 library so the forthcoming CLI never hand-rolls raw FTP verbs.

## Methods
- `Delete(name)` — DELE (250)
- `Mkdir(path)` — MKD (257)
- `Rename(from, to)` — RNFR/RNTO issued under a single hold of the session mutex (lock-atomic; non-interleaving verified under `-race`)
- `Chmod(mode, path)` — SITE CHMOD (200)
- `PurgeJob(jobID)` — DELE under FILETYPE=JES, filetype set/restored via defer

## Tests / mock
- `internal/mockzos` answers DELE/MKD/RNFR/RNTO for happy-path tests; error paths via `srv.Script`.
- Unit + race coverage for every method, including a concurrent no-interleave test for Rename.

## Gate
build / vet / staticcheck / `go test -race` / govulncheck — all green; `doc_coverage_test.go` passes.

PR A of A/B/C (library → CLI → release pipeline).