### PR TITLE
feat(cli): full cobra CLI over the v2 library

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -1,30 +1,177 @@
 # zftp CLI
 
-A command-line client built on the [`gopkg.in/ro-ag/zftp.v2`](../) z/OS FTP
-library.
+A command-line client for z/OS FTP built on the
+[`gopkg.in/ro-ag/zftp.v2`](../) library. Every command speaks directly to
+z/OS FTP — no middleware, no daemon.
 
-## Why a separate module?
-
-This directory is its own Go module (`github.com/ro-ag/zftp/cli`) with its own
-`go.mod`. That keeps the **library** dependency-free: anything the CLI needs for
-flag parsing, output formatting, or packaging lives here and never leaks into the
-import graph of applications that embed the library.
-
-During development the library is resolved from the parent directory via a
-`replace` directive; once `v2.0.0` is tagged that can be dropped.
-
-## Status
-
-This is a **skeleton**. It imports the library and reports its version to prove
-the module wiring and dependency isolation. The full client — subcommands
-(`ls`, `get`, `put`, `submit`, …) and downloadable, signed binaries produced by
-GoReleaser on tag — is tracked as a follow-up and is intentionally out of scope
-for the v2 library modernization.
-
-## Build
+## Install
 
 ```sh
-cd cli
-CGO_ENABLED=0 go build -o zftp .
-./zftp -version
+go install github.com/ro-ag/zftp/cli@latest
 ```
+
+> **Submodule / replace caveat:** this directory is its own Go module
+> (`github.com/ro-ag/zftp/cli`). During development the library is resolved
+> from the parent directory via a `replace` directive in `go.mod`; once
+> `v2.0.0` is tagged on `gopkg.in/ro-ag/zftp.v2` that directive is dropped
+> and `go install` works without a local clone.
+
+Homebrew tap and `docker run ghcr.io/ro-ag/zftp` are coming with the binary
+release pipeline (PR C).
+
+## Environment
+
+| Variable        | Purpose                                      |
+|-----------------|----------------------------------------------|
+| `ZFTP_HOST`     | z/OS FTP hostname (used as `--host` default) |
+| `ZFTP_USER`     | Login user (used as `--user` default)        |
+| `ZFTP_PASSWORD` | Login password                               |
+
+`ZFTP_PASSWORD` is read from the environment when set, otherwise the CLI
+prompts interactively with echo disabled. A password flag is intentionally
+absent — flags appear in shell history; env vars and prompts do not.
+
+## Global flags
+
+| Flag               | Description                                         |
+|--------------------|-----------------------------------------------------|
+| `-H`, `--host`     | z/OS FTP host (overrides `ZFTP_HOST`)               |
+| `-u`, `--user`     | Login user (overrides `ZFTP_USER`)                  |
+| `--port`           | Control port (default `21`)                         |
+| `--tls`            | AUTH TLS on the control connection                  |
+| `--tls-skip-verify`| Skip TLS certificate verification                   |
+| `--json`           | Machine-readable JSON output (applies to all cmds)  |
+| `-v`, `-vv`        | Protocol logging (`-v` commands/replies, `-vv` all) |
+| `--timeout`        | Control connection timeout (e.g. `30s`)             |
+
+## Commands
+
+### `version` — print build metadata
+
+```sh
+zftp version
+zftp version --json
+```
+
+### `ls` — list datasets, PDS members, or HFS entries
+
+```sh
+# List datasets matching a pattern (MVS LISTDS)
+zftp ls 'USER.*'
+
+# List PDS members
+zftp ls 'USER.JCLLIB' --pds
+
+# Raw HFS directory listing
+zftp ls '/u/me' --hfs
+```
+
+| Flag    | Description                     |
+|---------|---------------------------------|
+| `--pds` | List PDS members instead        |
+| `--hfs` | Raw HFS/LIST output             |
+
+### `get` — download a dataset or file (RETR)
+
+```sh
+zftp get 'USER.DATA.FB80' local.dat
+zftp get 'USER.DATA.FB80' --ascii local.txt
+zftp get 'USER.LARGE' --gzip  large.gz
+zftp get 'USER.LARGE' --offset 1048576 resume.dat
+```
+
+| Flag       | Description                                |
+|------------|--------------------------------------------|
+| `--ascii`  | ASCII (text) transfer; default is binary   |
+| `--gzip`   | Compress the downloaded stream             |
+| `--offset` | Resume at byte offset (binary only)        |
+
+### `put` — upload a file or dataset (STOR)
+
+```sh
+zftp put local.dat 'USER.DATA.FB80'
+zftp put local.txt 'USER.DATA.FB80' --ascii
+zftp put resume.dat 'USER.LARGE' --offset 1048576
+```
+
+| Flag       | Description                                |
+|------------|--------------------------------------------|
+| `--ascii`  | ASCII (text) transfer; default is binary   |
+| `--offset` | Resume at byte offset (binary only)        |
+
+### `rm` — delete a dataset or HFS file (DELE)
+
+```sh
+zftp rm 'USER.OLD.DATA'
+zftp rm '/u/me/tmp.txt'
+```
+
+### `mkdir` — create an HFS directory (MKD)
+
+```sh
+zftp mkdir '/u/me/newdir'
+```
+
+### `mv` — rename a dataset or file (RNFR/RNTO)
+
+```sh
+zftp mv 'USER.OLD' 'USER.NEW'
+```
+
+### `chmod` — change HFS permissions (SITE CHMOD)
+
+```sh
+zftp chmod 750 '/u/me/script.sh'
+```
+
+### `stat` — show z/OS system info and server status
+
+```sh
+zftp stat
+zftp stat --json
+```
+
+### `submit` — submit a JCL file to JES
+
+```sh
+zftp submit myjob.jcl
+```
+
+Returns the job ID (e.g. `JOB12345`).
+
+### `jobs` — list spool jobs
+
+```sh
+zftp jobs
+zftp jobs 'USER*'
+zftp jobs --json
+```
+
+### `job` — show a job's status/detail
+
+```sh
+zftp job JOB12345
+zftp job JOB12345 --json
+```
+
+#### `job purge` — purge a job from the spool
+
+```sh
+zftp job purge JOB12345
+```
+
+## JSON output
+
+Pass `--json` to any command (or use the per-command `--json` flag on
+`version`) to receive newline-delimited JSON suitable for `jq`:
+
+```sh
+zftp ls 'USER.*' --json | jq '.[].Dsname'
+zftp stat --json | jq '.system'
+zftp job JOB12345 --json | jq '.JobId'
+```
+
+## Follow-ups
+
+`submit --wait` (poll until complete) and `submit --fetch` (download output
+spool) are deferred to a later release and not yet implemented.

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -4,6 +4,14 @@ go 1.26
 
 require gopkg.in/ro-ag/zftp.v2 v2.0.0
 
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/cobra v1.10.2 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
+	golang.org/x/sys v0.46.0 // indirect
+	golang.org/x/term v0.44.0 // indirect
+)
+
 // During development (before v2.0.0 is tagged) and for local builds, resolve the
 // library from the parent directory. Release tooling can drop this.
 replace gopkg.in/ro-ag/zftp.v2 => ../

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -2,14 +2,16 @@ module github.com/ro-ag/zftp/cli
 
 go 1.26
 
-require gopkg.in/ro-ag/zftp.v2 v2.0.0
+require (
+	github.com/spf13/cobra v1.10.2
+	golang.org/x/term v0.44.0
+	gopkg.in/ro-ag/zftp.v2 v2.0.0
+)
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	golang.org/x/sys v0.46.0 // indirect
-	golang.org/x/term v0.44.0 // indirect
 )
 
 // During development (before v2.0.0 is tagged) and for local builds, resolve the

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -1,0 +1,14 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
+github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
+golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/term v0.44.0 h1:0rLvDRCtNj0gZkyIXhCyOb2OAzEhLVqc4B+hrsBhrmc=
+golang.org/x/term v0.44.0/go.mod h1:7ze4MdzUzLXpSAoFP1H0bOI9aXDqveSvatT5vKcFh2Y=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/cli/internal/cmd/cmd.go
+++ b/cli/internal/cmd/cmd.go
@@ -176,6 +176,7 @@ func newRootCmd(d deps, bi BuildInfo) *cobra.Command {
 		newMkdirCmd(d, g),
 		newMvCmd(d, g),
 		newChmodCmd(d, g),
+		newStatCmd(d, g),
 	)
 	root.SetOut(d.out)
 	root.SetErr(d.errOut)

--- a/cli/internal/cmd/cmd.go
+++ b/cli/internal/cmd/cmd.go
@@ -167,7 +167,10 @@ func newRootCmd(d deps, bi BuildInfo) *cobra.Command {
 	pf.CountVarP(&g.verbose, "verbose", "v", "increase protocol logging (-v, -vv)")
 	pf.DurationVar(&g.timeout, "timeout", 0, "control connection timeout (e.g. 30s)")
 
-	root.AddCommand(newVersionCmd(d, bi))
+	root.AddCommand(
+		newVersionCmd(d, bi),
+		newLsCmd(d, g),
+	)
 	root.SetOut(d.out)
 	root.SetErr(d.errOut)
 	return root

--- a/cli/internal/cmd/cmd.go
+++ b/cli/internal/cmd/cmd.go
@@ -172,6 +172,10 @@ func newRootCmd(d deps, bi BuildInfo) *cobra.Command {
 		newLsCmd(d, g),
 		newGetCmd(d, g),
 		newPutCmd(d, g),
+		newRmCmd(d, g),
+		newMkdirCmd(d, g),
+		newMvCmd(d, g),
+		newChmodCmd(d, g),
 	)
 	root.SetOut(d.out)
 	root.SetErr(d.errOut)

--- a/cli/internal/cmd/cmd.go
+++ b/cli/internal/cmd/cmd.go
@@ -177,6 +177,9 @@ func newRootCmd(d deps, bi BuildInfo) *cobra.Command {
 		newMvCmd(d, g),
 		newChmodCmd(d, g),
 		newStatCmd(d, g),
+		newSubmitCmd(d, g),
+		newJobsCmd(d, g),
+		newJobCmd(d, g),
 	)
 	root.SetOut(d.out)
 	root.SetErr(d.errOut)

--- a/cli/internal/cmd/cmd.go
+++ b/cli/internal/cmd/cmd.go
@@ -170,6 +170,8 @@ func newRootCmd(d deps, bi BuildInfo) *cobra.Command {
 	root.AddCommand(
 		newVersionCmd(d, bi),
 		newLsCmd(d, g),
+		newGetCmd(d, g),
+		newPutCmd(d, g),
 	)
 	root.SetOut(d.out)
 	root.SetErr(d.errOut)

--- a/cli/internal/cmd/cmd.go
+++ b/cli/internal/cmd/cmd.go
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package cmd implements the zftp command-line client. Every command is built by
+// a newXCmd(deps) constructor and depends only on the injected deps, so commands
+// are unit-testable against a fake client with no network, stdout, or terminal.
+package cmd
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+	"gopkg.in/ro-ag/zftp.v2"
+	"gopkg.in/ro-ag/zftp.v2/hfs"
+)
+
+// client is the narrow slice of *FTPSession the commands use. *zftp.FTPSession
+// satisfies it structurally; tests inject a fake.
+type client interface {
+	ListDatasets(expression string) ([]hfs.InfoDataset, error)
+	List(expression string) ([]string, error)
+	ListPds(expression string) ([]hfs.InfoPdsMember, error)
+	ListSpool(expression string) ([]hfs.InfoJob, error)
+	Get(remote, local string, mode zftp.TransferType) error
+	GetAt(remote, local string, mode zftp.TransferType, offset int64) error
+	GetAndGzip(remote, local string, mode zftp.TransferType) error
+	Put(local, remote string, mode zftp.TransferType, a ...zftp.DataSpec) error
+	PutAt(local, remote string, mode zftp.TransferType, offset int64, a ...zftp.DataSpec) error
+	Delete(name string) error
+	Mkdir(path string) error
+	Rename(from, to string) error
+	Chmod(mode, path string) error
+	SubmitJCLFile(jclFile string, options ...zftp.JesSpec) (*zftp.JesJob, error)
+	GetJobStatus(jobID string) (*hfs.InfoJobDetail, error)
+	PurgeJob(jobID string) error
+	StatusOf() *zftp.ServerStatus
+	System() (string, error)
+	Close() error
+}
+
+// connOpts carries the resolved connection parameters for the connect factory.
+type connOpts struct {
+	host, port       string
+	user, pass       string
+	tls, tlsNoVerify bool
+	timeout          time.Duration
+	verbosity        int
+}
+
+// deps holds every external effect the commands touch — the only seam to the
+// outside world. Production wires real implementations; tests wire fakes.
+type deps struct {
+	connect func(o connOpts) (client, error)
+	getenv  func(string) string
+	prompt  func() (string, error) // no-echo password reader
+	out     io.Writer
+	errOut  io.Writer
+}
+
+// BuildInfo is the version metadata injected by GoReleaser ldflags via main.
+type BuildInfo struct{ Version, Commit, Date string }
+
+// globalFlags are the persistent connection flags shared by all commands.
+type globalFlags struct {
+	host, port, user   string
+	tlsOn, tlsNoVerify bool
+	jsonOut            bool
+	verbose            int
+	timeout            time.Duration
+}
+
+// resolvePassword returns ZFTP_PASSWORD if set, else the interactive prompt. It
+// never accepts a password flag.
+func resolvePassword(getenv func(string) string, prompt func() (string, error)) (string, error) {
+	if p := getenv("ZFTP_PASSWORD"); p != "" {
+		return p, nil
+	}
+	return prompt()
+}
+
+// emit writes v as indented JSON when jsonOut, else renders the human table.
+func emit(d deps, jsonOut bool, v any, table func(w io.Writer)) error {
+	if jsonOut {
+		enc := json.NewEncoder(d.out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(v)
+	}
+	table(d.out)
+	return nil
+}
+
+// dial resolves the password and opens an authenticated session via d.connect.
+func dial(d deps, g *globalFlags) (client, error) {
+	pass, err := resolvePassword(d.getenv, d.prompt)
+	if err != nil {
+		return nil, fmt.Errorf("password: %w", err)
+	}
+	return d.connect(connOpts{
+		host: g.host, port: g.port, user: g.user, pass: pass,
+		tls: g.tlsOn, tlsNoVerify: g.tlsNoVerify, timeout: g.timeout, verbosity: g.verbose,
+	})
+}
+
+// realConnect dials, optionally upgrades to TLS, and logs in.
+func realConnect(o connOpts) (client, error) {
+	opts := []zftp.Option{zftp.WithSignalHandler()}
+	if o.timeout > 0 {
+		opts = append(opts, zftp.WithTimeout(o.timeout))
+	}
+	if o.verbosity > 0 {
+		opts = append(opts, zftp.WithLogger(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))))
+	}
+	s, err := zftp.Open(net.JoinHostPort(o.host, o.port), opts...)
+	if err != nil {
+		return nil, err
+	}
+	if o.tls {
+		cfg := &tls.Config{ServerName: o.host, InsecureSkipVerify: o.tlsNoVerify} //nolint:gosec // opt-in via --tls-skip-verify
+		if err := s.AuthTLS(cfg); err != nil {
+			_ = s.Close()
+			return nil, err
+		}
+	}
+	if err := s.Login(o.user, o.pass); err != nil {
+		_ = s.Close()
+		return nil, err
+	}
+	if o.verbosity == 1 {
+		s.SetVerbose(zftp.LogCommand | zftp.LogServer)
+	} else if o.verbosity > 1 {
+		s.SetVerbose(zftp.LogAll)
+	}
+	return s, nil
+}
+
+// termPrompt reads a password from the controlling terminal with echo disabled.
+func termPrompt() (string, error) {
+	fmt.Fprint(os.Stderr, "Password: ")
+	b, err := term.ReadPassword(int(os.Stdin.Fd()))
+	fmt.Fprintln(os.Stderr)
+	return string(b), err
+}
+
+// newRootCmd assembles the command tree with persistent connection flags.
+func newRootCmd(d deps, bi BuildInfo) *cobra.Command {
+	g := &globalFlags{}
+	root := &cobra.Command{
+		Use:           "zftp",
+		Short:         "Pure-Go z/OS FTP client",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	pf := root.PersistentFlags()
+	pf.StringVarP(&g.host, "host", "H", envOr(d, "ZFTP_HOST", ""), "z/OS FTP host")
+	pf.StringVar(&g.port, "port", "21", "control port")
+	pf.StringVarP(&g.user, "user", "u", envOr(d, "ZFTP_USER", ""), "login user")
+	pf.BoolVar(&g.tlsOn, "tls", false, "AUTH TLS on the control connection")
+	pf.BoolVar(&g.tlsNoVerify, "tls-skip-verify", false, "skip TLS certificate verification")
+	pf.BoolVar(&g.jsonOut, "json", false, "machine-readable JSON output")
+	pf.CountVarP(&g.verbose, "verbose", "v", "increase protocol logging (-v, -vv)")
+	pf.DurationVar(&g.timeout, "timeout", 0, "control connection timeout (e.g. 30s)")
+
+	// Subcommands are wired in by later tasks (version, ls, get, put, rm/mkdir/mv/chmod, stat, submit/jobs/job).
+	// root.AddCommand(...) populated incrementally.
+	root.SetOut(d.out)
+	root.SetErr(d.errOut)
+	_ = bi // used by newVersionCmd in a later task
+	return root
+}
+
+func envOr(d deps, key, def string) string {
+	if v := d.getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+// Execute builds production deps and runs the CLI. Returns an error; main maps it
+// to a non-zero exit. This is the ONLY place that reads the real environment.
+func Execute(bi BuildInfo) error {
+	d := deps{
+		connect: realConnect,
+		getenv:  os.Getenv,
+		prompt:  termPrompt,
+		out:     os.Stdout,
+		errOut:  os.Stderr,
+	}
+	return newRootCmd(d, bi).Execute()
+}

--- a/cli/internal/cmd/cmd.go
+++ b/cli/internal/cmd/cmd.go
@@ -167,11 +167,9 @@ func newRootCmd(d deps, bi BuildInfo) *cobra.Command {
 	pf.CountVarP(&g.verbose, "verbose", "v", "increase protocol logging (-v, -vv)")
 	pf.DurationVar(&g.timeout, "timeout", 0, "control connection timeout (e.g. 30s)")
 
-	// Subcommands are wired in by later tasks (version, ls, get, put, rm/mkdir/mv/chmod, stat, submit/jobs/job).
-	// root.AddCommand(...) populated incrementally.
+	root.AddCommand(newVersionCmd(d, bi))
 	root.SetOut(d.out)
 	root.SetErr(d.errOut)
-	_ = bi // used by newVersionCmd in a later task
 	return root
 }
 

--- a/cli/internal/cmd/cmd_test.go
+++ b/cli/internal/cmd/cmd_test.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+
+	"gopkg.in/ro-ag/zftp.v2"
+)
+
+// *FTPSession must satisfy the narrow client interface the commands consume.
+var _ client = (*zftp.FTPSession)(nil)
+
+func TestResolvePassword_EnvWins(t *testing.T) {
+	env := map[string]string{"ZFTP_PASSWORD": "secret"}
+	got, err := resolvePassword(func(k string) string { return env[k] },
+		func() (string, error) { return "", errors.New("prompt must not be called") })
+	if err != nil || got != "secret" {
+		t.Fatalf("resolvePassword = (%q,%v), want (secret,nil)", got, err)
+	}
+}
+
+func TestResolvePassword_PromptFallback(t *testing.T) {
+	got, err := resolvePassword(func(string) string { return "" },
+		func() (string, error) { return "typed", nil })
+	if err != nil || got != "typed" {
+		t.Fatalf("resolvePassword = (%q,%v), want (typed,nil)", got, err)
+	}
+}
+
+func TestEmit_JSON(t *testing.T) {
+	var buf bytes.Buffer
+	d := deps{out: &buf}
+	if err := emit(d, true, map[string]string{"a": "b"}, func(w io.Writer) {}); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(buf.Bytes(), []byte(`"a": "b"`)) {
+		t.Fatalf("json output = %s", buf.String())
+	}
+}

--- a/cli/internal/cmd/coverage_test.go
+++ b/cli/internal/cmd/coverage_test.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"gopkg.in/ro-ag/zftp.v2/hfs"
+)
+
+// TestLsCmd_PDS verifies the --pds flag calls ListPds and renders the member name.
+func TestLsCmd_PDS(t *testing.T) {
+	// "ARTIST    01.00 2021/08/20 2021/08/20 07:51     6     6     0 A99993"
+	// is 69 chars — at or past idStart (61), so statistics are parsed.
+	m, err := hfs.ParseInfoPdsMember("COBOL01   01.00 2024/06/20 2024/06/20 10:30   100   100     0 USER001")
+	if err != nil {
+		t.Fatalf("ParseInfoPdsMember: %v", err)
+	}
+	fake := &fakeClient{pds: []hfs.InfoPdsMember{m}}
+	env := map[string]string{"ZFTP_PASSWORD": "pw"}
+	out, err := runCLI(t, fake, env, "ls", "X.*", "--pds", "-H", "h", "-u", "me")
+	if err != nil {
+		t.Fatalf("ls --pds error: %v", err)
+	}
+	if !strings.Contains(out, "COBOL01") {
+		t.Errorf("output missing member name, got: %s", out)
+	}
+	if !contains(fake.calls, "ListPds:X.*") {
+		t.Errorf("ListPds:X.* not in calls %v", fake.calls)
+	}
+}
+
+// TestLsCmd_HFS verifies the --hfs flag calls List and prints each line.
+func TestLsCmd_HFS(t *testing.T) {
+	fake := &fakeClient{listLines: []string{"/u/me/file1", "/u/me/file2"}}
+	env := map[string]string{"ZFTP_PASSWORD": "pw"}
+	out, err := runCLI(t, fake, env, "ls", "/u/me/*", "--hfs", "-H", "h", "-u", "me")
+	if err != nil {
+		t.Fatalf("ls --hfs error: %v", err)
+	}
+	if !strings.Contains(out, "/u/me/file1") {
+		t.Errorf("output missing /u/me/file1, got: %s", out)
+	}
+	if !strings.Contains(out, "/u/me/file2") {
+		t.Errorf("output missing /u/me/file2, got: %s", out)
+	}
+	if !contains(fake.calls, "List:/u/me/*") {
+		t.Errorf("List:/u/me/* not in calls %v", fake.calls)
+	}
+}
+
+// TestLsCmd_Error verifies ls propagates a client error.
+func TestLsCmd_Error(t *testing.T) {
+	fake := &fakeClient{err: errors.New("boom")}
+	env := map[string]string{"ZFTP_PASSWORD": "pw"}
+	_, err := runCLI(t, fake, env, "ls", "X.*", "-H", "h", "-u", "me")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+// TestGetCmd_ASCII verifies --ascii exercises the ascii branch of transferType.
+func TestGetCmd_ASCII(t *testing.T) {
+	fake := &fakeClient{}
+	env := map[string]string{"ZFTP_HOST": "h", "ZFTP_USER": "me", "ZFTP_PASSWORD": "pw"}
+	_, err := runCLI(t, fake, env, "get", "REMOTE", "local", "--ascii")
+	if err != nil {
+		t.Fatalf("get --ascii error: %v", err)
+	}
+	if !contains(fake.calls, "Get:REMOTE->local") {
+		t.Errorf("Get:REMOTE->local not in calls %v", fake.calls)
+	}
+}
+
+// TestStatCmd_Error verifies stat propagates a System() error.
+func TestStatCmd_Error(t *testing.T) {
+	fake := &fakeClient{err: errors.New("syst failed"), system: ""}
+	env := map[string]string{"ZFTP_PASSWORD": "pw"}
+	_, err := runCLI(t, fake, env, "stat", "-H", "h", "-u", "me")
+	if err == nil {
+		t.Fatal("expected error from stat, got nil")
+	}
+	if !strings.Contains(err.Error(), "syst failed") {
+		t.Errorf("expected 'syst failed' in error, got: %v", err)
+	}
+}
+
+// TestDial_PasswordPromptError verifies that a prompt failure is wrapped and returned
+// before the connect func is called.
+func TestDial_PasswordPromptError(t *testing.T) {
+	var out, errOut bytes.Buffer
+	d := deps{
+		connect: func(connOpts) (client, error) {
+			return nil, errors.New("should not be called")
+		},
+		getenv: func(string) string { return "" }, // no ZFTP_PASSWORD
+		prompt: func() (string, error) { return "", errors.New("no tty") },
+		out:    &out,
+		errOut: &errOut,
+	}
+	root := newRootCmd(d, BuildInfo{Version: "test"})
+	root.SetArgs([]string{"ls", "X.*", "-H", "h", "-u", "me"})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected error from prompt failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "no tty") {
+		t.Errorf("expected 'no tty' in error, got: %v", err)
+	}
+}
+
+// TestWithClient_DialConnectError verifies that a connect() failure is returned
+// from withClient without calling the wrapped function.
+func TestWithClient_DialConnectError(t *testing.T) {
+	var out, errOut bytes.Buffer
+	d := deps{
+		connect: func(connOpts) (client, error) { return nil, errors.New("dial fail") },
+		getenv:  func(k string) string { m := map[string]string{"ZFTP_PASSWORD": "pw"}; return m[k] },
+		prompt:  func() (string, error) { return "pw", nil },
+		out:     &out,
+		errOut:  &errOut,
+	}
+	root := newRootCmd(d, BuildInfo{Version: "test"})
+	root.SetArgs([]string{"rm", "USER.A", "-H", "h", "-u", "me"})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected dial error, got nil")
+	}
+	if !strings.Contains(err.Error(), "dial fail") {
+		t.Errorf("expected 'dial fail' in error, got: %v", err)
+	}
+}
+
+// TestJobCmd_JSON verifies --json output from the job command decodes and contains a JobId.
+func TestJobCmd_JSON(t *testing.T) {
+	fake := &fakeClient{jobDetail: makeInfoJobDetail(t)}
+	env := map[string]string{"ZFTP_PASSWORD": "pw"}
+	out, err := runCLI(t, fake, env, "job", "JOB12345", "--json", "-H", "h", "-u", "me")
+	if err != nil {
+		t.Fatalf("job --json error: %v", err)
+	}
+	var obj map[string]any
+	if jsonErr := json.Unmarshal([]byte(out), &obj); jsonErr != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput: %s", jsonErr, out)
+	}
+	jobID, ok := obj["JobId"]
+	if !ok {
+		t.Errorf("JSON output missing 'JobId' key, got keys: %v, output: %s", obj, out)
+	}
+	if jobID == "" || jobID == nil {
+		t.Errorf("expected non-empty JobId, got: %v", jobID)
+	}
+}

--- a/cli/internal/cmd/fake_test.go
+++ b/cli/internal/cmd/fake_test.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"gopkg.in/ro-ag/zftp.v2"
+	"gopkg.in/ro-ag/zftp.v2/hfs"
+)
+
+// fakeClient is a test double that satisfies the client interface. Fields are
+// pre-loaded with canned responses; calls logs each method invocation for
+// sequence assertions.
+type fakeClient struct {
+	calls     []string // method:arg log for sequence assertions
+	datasets  []hfs.InfoDataset
+	listLines []string
+	pds       []hfs.InfoPdsMember
+	jobs      []hfs.InfoJob
+	jobDetail *hfs.InfoJobDetail
+	submitJob *zftp.JesJob
+	status    *zftp.ServerStatus
+	system    string
+	err       error // returned by the next mutating call when set
+}
+
+func (f *fakeClient) ListDatasets(e string) ([]hfs.InfoDataset, error) {
+	f.calls = append(f.calls, "ListDatasets:"+e)
+	return f.datasets, f.err
+}
+func (f *fakeClient) List(e string) ([]string, error) {
+	f.calls = append(f.calls, "List:"+e)
+	return f.listLines, f.err
+}
+func (f *fakeClient) ListPds(e string) ([]hfs.InfoPdsMember, error) {
+	f.calls = append(f.calls, "ListPds:"+e)
+	return f.pds, f.err
+}
+func (f *fakeClient) ListSpool(e string) ([]hfs.InfoJob, error) {
+	f.calls = append(f.calls, "ListSpool:"+e)
+	return f.jobs, f.err
+}
+func (f *fakeClient) Get(r, l string, m zftp.TransferType) error {
+	f.calls = append(f.calls, "Get:"+r+"->"+l)
+	return f.err
+}
+func (f *fakeClient) GetAt(r, l string, m zftp.TransferType, o int64) error {
+	f.calls = append(f.calls, "GetAt:"+r)
+	return f.err
+}
+func (f *fakeClient) GetAndGzip(r, l string, m zftp.TransferType) error {
+	f.calls = append(f.calls, "GetAndGzip:"+r)
+	return f.err
+}
+func (f *fakeClient) Put(l, r string, m zftp.TransferType, a ...zftp.DataSpec) error {
+	f.calls = append(f.calls, "Put:"+l+"->"+r)
+	return f.err
+}
+func (f *fakeClient) PutAt(l, r string, m zftp.TransferType, o int64, a ...zftp.DataSpec) error {
+	f.calls = append(f.calls, "PutAt:"+l)
+	return f.err
+}
+func (f *fakeClient) Delete(n string) error {
+	f.calls = append(f.calls, "Delete:"+n)
+	return f.err
+}
+func (f *fakeClient) Mkdir(p string) error {
+	f.calls = append(f.calls, "Mkdir:"+p)
+	return f.err
+}
+func (f *fakeClient) Rename(a, b string) error {
+	f.calls = append(f.calls, "Rename:"+a+"->"+b)
+	return f.err
+}
+func (f *fakeClient) Chmod(m, p string) error {
+	f.calls = append(f.calls, "Chmod:"+m+" "+p)
+	return f.err
+}
+func (f *fakeClient) SubmitJCLFile(j string, o ...zftp.JesSpec) (*zftp.JesJob, error) {
+	f.calls = append(f.calls, "SubmitJCLFile:"+j)
+	return f.submitJob, f.err
+}
+func (f *fakeClient) GetJobStatus(id string) (*hfs.InfoJobDetail, error) {
+	f.calls = append(f.calls, "GetJobStatus:"+id)
+	return f.jobDetail, f.err
+}
+func (f *fakeClient) PurgeJob(id string) error {
+	f.calls = append(f.calls, "PurgeJob:"+id)
+	return f.err
+}
+func (f *fakeClient) StatusOf() *zftp.ServerStatus { return f.status }
+func (f *fakeClient) System() (string, error)      { return f.system, f.err }
+func (f *fakeClient) Close() error {
+	f.calls = append(f.calls, "Close")
+	return nil
+}
+
+// runCLI builds a root command wired to fake (via deps.connect) and the given
+// env, executes argv, and returns captured stdout.
+func runCLI(t *testing.T, fake *fakeClient, env map[string]string, argv ...string) (string, error) {
+	t.Helper()
+	var out bytes.Buffer
+	d := deps{
+		connect: func(connOpts) (client, error) { return fake, nil },
+		getenv:  func(k string) string { return env[k] },
+		prompt:  func() (string, error) { return "pw", nil },
+		out:     &out, errOut: &out,
+	}
+	root := newRootCmd(d, BuildInfo{Version: "test"})
+	root.SetArgs(argv)
+	err := root.Execute()
+	return out.String(), err
+}

--- a/cli/internal/cmd/get.go
+++ b/cli/internal/cmd/get.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+package cmd
+
+import (
+	"errors"
+	"path"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/ro-ag/zftp.v2"
+)
+
+// transferType maps the --ascii flag to the corresponding zftp transfer mode.
+// When ascii is false (the default) binary/image mode is used.
+func transferType(ascii bool) zftp.TransferType {
+	if ascii {
+		return zftp.TypeAscii
+	}
+	return zftp.TypeImage
+}
+
+// newGetCmd returns the "get" sub-command (RETR). It downloads a remote dataset
+// or file to a local path, with optional gzip compression or byte-offset resume.
+func newGetCmd(d deps, g *globalFlags) *cobra.Command {
+	var ascii, gzipOut bool
+	var offset int64
+	c := &cobra.Command{
+		Use:   "get <remote> [local]",
+		Short: "Download a dataset or file (RETR)",
+		Args:  cobra.RangeArgs(1, 2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			remote := args[0]
+			local := path.Base(strings.Trim(remote, "'"))
+			if len(args) == 2 {
+				local = args[1]
+			}
+			if ascii && offset > 0 {
+				return errors.New("--offset is binary-only; ASCII resume is unsupported")
+			}
+			conn, err := dial(d, g)
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+			mode := transferType(ascii)
+			switch {
+			case gzipOut:
+				return conn.GetAndGzip(remote, local, mode)
+			case offset > 0:
+				return conn.GetAt(remote, local, mode, offset)
+			default:
+				return conn.Get(remote, local, mode)
+			}
+		},
+	}
+	c.Flags().BoolVar(&ascii, "ascii", false, "ASCII (text) transfer; default is binary")
+	c.Flags().BoolVar(&gzipOut, "gzip", false, "gzip the downloaded stream")
+	c.Flags().Int64Var(&offset, "offset", 0, "resume at byte offset (binary only)")
+	return c
+}

--- a/cli/internal/cmd/get_test.go
+++ b/cli/internal/cmd/get_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGet(t *testing.T) {
+	env := map[string]string{
+		"ZFTP_HOST": "localhost",
+		"ZFTP_USER": "user",
+	}
+
+	t.Run("get REMOTE local", func(t *testing.T) {
+		fake := &fakeClient{}
+		_, err := runCLI(t, fake, env, "get", "REMOTE", "local")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := "Get:REMOTE->local"
+		if !contains(fake.calls, want) {
+			t.Errorf("calls %v does not contain %q", fake.calls, want)
+		}
+	})
+
+	t.Run("gzip", func(t *testing.T) {
+		fake := &fakeClient{}
+		_, err := runCLI(t, fake, env, "get", "--gzip", "REMOTE", "local")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := "GetAndGzip:REMOTE"
+		if !contains(fake.calls, want) {
+			t.Errorf("calls %v does not contain %q", fake.calls, want)
+		}
+	})
+
+	t.Run("offset", func(t *testing.T) {
+		fake := &fakeClient{}
+		_, err := runCLI(t, fake, env, "get", "--offset", "100", "REMOTE", "local")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := "GetAt:REMOTE"
+		if !contains(fake.calls, want) {
+			t.Errorf("calls %v does not contain %q", fake.calls, want)
+		}
+	})
+
+	t.Run("ascii+offset rejected before dial", func(t *testing.T) {
+		fake := &fakeClient{}
+		_, err := runCLI(t, fake, env, "get", "--ascii", "--offset", "100", "REMOTE", "local")
+		if err == nil {
+			t.Fatal("expected error for --ascii --offset, got nil")
+		}
+		for _, c := range fake.calls {
+			if strings.HasPrefix(c, "GetAt:") {
+				t.Errorf("GetAt was called despite rejection: calls=%v", fake.calls)
+			}
+		}
+	})
+
+	t.Run("default local basename", func(t *testing.T) {
+		fake := &fakeClient{}
+		_, err := runCLI(t, fake, env, "get", "'MY.DATASET'")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := "Get:'MY.DATASET'->MY.DATASET"
+		if !contains(fake.calls, want) {
+			t.Errorf("calls %v does not contain %q", fake.calls, want)
+		}
+	})
+}
+
+func contains(calls []string, want string) bool {
+	for _, c := range calls {
+		if c == want {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/internal/cmd/jes.go
+++ b/cli/internal/cmd/jes.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+)
+
+// newSubmitCmd returns the submit subcommand that sends a JCL file to JES.
+func newSubmitCmd(d deps, g *globalFlags) *cobra.Command {
+	return &cobra.Command{
+		Use:   "submit <jclfile>",
+		Short: "Submit a JCL file to JES (returns the job id)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, a []string) error {
+			return withClient(d, g, func(c client) error {
+				job, err := c.SubmitJCLFile(a[0])
+				if err != nil {
+					return err
+				}
+				return emit(d, g.jsonOut, job, func(w io.Writer) { fmt.Fprintln(w, job.ID) })
+			})
+		},
+	}
+}
+
+// newJobsCmd returns the jobs subcommand that lists spool jobs.
+func newJobsCmd(d deps, g *globalFlags) *cobra.Command {
+	return &cobra.Command{
+		Use:   "jobs [pattern]",
+		Short: "List spool jobs",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, a []string) error {
+			pat := "*"
+			if len(a) == 1 {
+				pat = a[0]
+			}
+			return withClient(d, g, func(c client) error {
+				js, err := c.ListSpool(pat)
+				if err != nil {
+					return err
+				}
+				return emit(d, g.jsonOut, js, func(w io.Writer) {
+					tw := tabwriter.NewWriter(w, 0, 2, 2, ' ', 0)
+					fmt.Fprintln(tw, "JOBNAME\tJOBID\tOWNER\tSTATUS\tCLASS")
+					for i := range js {
+						fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
+							js[i].Name.String(), js[i].JobId.String(),
+							js[i].Owner.String(), js[i].Status.String(),
+							js[i].Class.String())
+					}
+					tw.Flush()
+				})
+			})
+		},
+	}
+}
+
+// newJobCmd returns the job subcommand that shows a job's status/detail and
+// hosts the job purge subcommand.
+//
+// Fix 1: InfoJob has no .String() on the struct value — call fields explicitly.
+// Fix 2: emit jd.Job() (InfoJob, exported fields) not jd (*InfoJobDetail, unexported).
+func newJobCmd(d deps, g *globalFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "job <id>",
+		Short: "Show a job's status/detail",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, a []string) error {
+			return withClient(d, g, func(c client) error {
+				jd, err := c.GetJobStatus(a[0])
+				if err != nil {
+					return err
+				}
+				job := jd.Job()
+				// Emit job (InfoJob, exported json-tagged fields) for JSON so the
+				// output is a real object rather than {}. For the human render,
+				// print the fields explicitly — InfoJob.String() exists only as a
+				// pointer receiver (*InfoJob) and is not called on the value here.
+				return emit(d, g.jsonOut, job, func(w io.Writer) {
+					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+						job.Name.String(), job.JobId.String(),
+						job.Owner.String(), job.Status.String(),
+						job.Class.String())
+				})
+			})
+		},
+	}
+	cmd.AddCommand(&cobra.Command{
+		Use:   "purge <id>",
+		Short: "Purge a job from the spool (DELE under FILETYPE=JES)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, a []string) error {
+			return withClient(d, g, func(c client) error { return c.PurgeJob(a[0]) })
+		},
+	})
+	return cmd
+}

--- a/cli/internal/cmd/jes_test.go
+++ b/cli/internal/cmd/jes_test.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+package cmd
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"gopkg.in/ro-ag/zftp.v2"
+	"gopkg.in/ro-ag/zftp.v2/hfs"
+)
+
+func TestSubmitCmd_Table(t *testing.T) {
+	fake := &fakeClient{submitJob: &zftp.JesJob{ID: "JOB12345"}}
+	env := map[string]string{"ZFTP_PASSWORD": "pw"}
+	out, err := runCLI(t, fake, env, "submit", "job.jcl", "-H", "h", "-u", "me")
+	if err != nil {
+		t.Fatalf("submit error: %v", err)
+	}
+	if !strings.Contains(out, "JOB12345") {
+		t.Errorf("output missing job ID, got: %s", out)
+	}
+	found := false
+	for _, c := range fake.calls {
+		if c == "SubmitJCLFile:job.jcl" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("SubmitJCLFile:job.jcl not in calls %v", fake.calls)
+	}
+}
+
+func TestSubmitCmd_JSON(t *testing.T) {
+	fake := &fakeClient{submitJob: &zftp.JesJob{ID: "JOB12345"}}
+	env := map[string]string{"ZFTP_PASSWORD": "pw"}
+	out, err := runCLI(t, fake, env, "submit", "--json", "job.jcl", "-H", "h", "-u", "me")
+	if err != nil {
+		t.Fatalf("submit --json error: %v", err)
+	}
+	var obj map[string]any
+	if jsonErr := json.Unmarshal([]byte(out), &obj); jsonErr != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput: %s", jsonErr, out)
+	}
+	// JesJob has no json tags so fields marshal as their Go name (uppercase)
+	if _, ok := obj["ID"]; !ok {
+		t.Errorf("JSON output missing 'ID' key, got keys: %v, output: %s", obj, out)
+	}
+	if obj["ID"] != "JOB12345" {
+		t.Errorf("expected ID=JOB12345, got: %v", obj["ID"])
+	}
+}
+
+func makeInfoJobs(t *testing.T) []hfs.InfoJob {
+	t.Helper()
+	lines := []string{
+		"JOBNAME  JOBID    OWNER    STATUS CLASS",
+		"MYJOB    JOB12345 USER     OUTPUT A",
+	}
+	jobs, err := hfs.ParseInfoJob(lines)
+	if err != nil {
+		t.Fatalf("ParseInfoJob: %v", err)
+	}
+	return jobs
+}
+
+func makeInfoJobDetail(t *testing.T) *hfs.InfoJobDetail {
+	t.Helper()
+	lines := []string{
+		"JOBNAME  JOBID    OWNER    STATUS CLASS",
+		"MYJOB    JOB12345 USER     OUTPUT A        RC=0000",
+	}
+	jd, err := hfs.ParseInfoJobDetail(lines)
+	if err != nil {
+		t.Fatalf("ParseInfoJobDetail: %v", err)
+	}
+	return jd
+}
+
+func TestJobsCmd_Table(t *testing.T) {
+	fake := &fakeClient{jobs: makeInfoJobs(t)}
+	env := map[string]string{"ZFTP_PASSWORD": "pw"}
+	out, err := runCLI(t, fake, env, "jobs", "*", "-H", "h", "-u", "me")
+	if err != nil {
+		t.Fatalf("jobs error: %v", err)
+	}
+	if !strings.Contains(out, "MYJOB") {
+		t.Errorf("output missing job name, got: %s", out)
+	}
+	found := false
+	for _, c := range fake.calls {
+		if c == "ListSpool:*" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("ListSpool:* not in calls %v", fake.calls)
+	}
+}
+
+func TestJobCmd_Detail(t *testing.T) {
+	fake := &fakeClient{jobDetail: makeInfoJobDetail(t)}
+	env := map[string]string{"ZFTP_PASSWORD": "pw"}
+	_, err := runCLI(t, fake, env, "job", "JOB12345", "-H", "h", "-u", "me")
+	if err != nil {
+		t.Fatalf("job error: %v", err)
+	}
+	found := false
+	for _, c := range fake.calls {
+		if c == "GetJobStatus:JOB12345" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("GetJobStatus:JOB12345 not in calls %v", fake.calls)
+	}
+}
+
+func TestJobCmd_Purge(t *testing.T) {
+	fake := &fakeClient{}
+	env := map[string]string{"ZFTP_PASSWORD": "pw"}
+	_, err := runCLI(t, fake, env, "job", "purge", "JOB12345", "-H", "h", "-u", "me")
+	if err != nil {
+		t.Fatalf("job purge error: %v", err)
+	}
+	found := false
+	for _, c := range fake.calls {
+		if c == "PurgeJob:JOB12345" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("PurgeJob:JOB12345 not in calls %v", fake.calls)
+	}
+}

--- a/cli/internal/cmd/ls.go
+++ b/cli/internal/cmd/ls.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+)
+
+// newLsCmd returns the "ls" subcommand, which lists datasets (default), PDS
+// members (--pds), or raw HFS entries (--hfs).
+func newLsCmd(d deps, g *globalFlags) *cobra.Command {
+	var pds, hfsMode bool
+	c := &cobra.Command{
+		Use:   "ls [pattern]",
+		Short: "List datasets (default), PDS members (--pds), or HFS entries (--hfs)",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			pattern := "*"
+			if len(args) == 1 {
+				pattern = args[0]
+			}
+			c, err := dial(d, g)
+			if err != nil {
+				return err
+			}
+			defer c.Close()
+			switch {
+			case hfsMode:
+				lines, err := c.List(pattern)
+				if err != nil {
+					return err
+				}
+				return emit(d, g.jsonOut, lines, func(w io.Writer) {
+					for _, l := range lines {
+						fmt.Fprintln(w, l)
+					}
+				})
+			case pds:
+				ms, err := c.ListPds(pattern)
+				if err != nil {
+					return err
+				}
+				return emit(d, g.jsonOut, ms, func(w io.Writer) {
+					tw := tabwriter.NewWriter(w, 0, 2, 2, ' ', 0)
+					fmt.Fprintln(tw, "NAME\tVV.MM\tCHANGED\tSIZE\tID")
+					for i := range ms {
+						fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", ms[i].Name.String(), ms[i].VvMm.String(), ms[i].Changed.String(), ms[i].Size.String(), ms[i].Id.String())
+					}
+					tw.Flush()
+				})
+			default:
+				ds, err := c.ListDatasets(pattern)
+				if err != nil {
+					return err
+				}
+				return emit(d, g.jsonOut, ds, func(w io.Writer) {
+					tw := tabwriter.NewWriter(w, 0, 2, 2, ' ', 0)
+					fmt.Fprintln(tw, "NAME\tVOLUME\tRECFM\tLRECL\tDSORG\tSTATE")
+					for i := range ds {
+						fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n", ds[i].Name(), ds[i].Volume.String(), ds[i].Recfm.String(), ds[i].Lrecl.String(), ds[i].Dsorg.String(), ds[i].State())
+					}
+					tw.Flush()
+				})
+			}
+		},
+	}
+	c.Flags().BoolVar(&pds, "pds", false, "list PDS members")
+	c.Flags().BoolVar(&hfsMode, "hfs", false, "raw HFS/LIST output")
+	return c
+}

--- a/cli/internal/cmd/ls_test.go
+++ b/cli/internal/cmd/ls_test.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+package cmd
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"gopkg.in/ro-ag/zftp.v2/hfs"
+)
+
+// makeDataset builds an hfs.InfoDataset fixture via JSON unmarshal so the
+// unexported FieldString/FieldInt internals are populated correctly.
+func makeDataset(t *testing.T) hfs.InfoDataset {
+	t.Helper()
+	var ds hfs.InfoDataset
+	if err := json.Unmarshal([]byte(`{"Dsname":"USER.DATA","Volume":"VOL001","Recfm":"FB","Lrecl":80,"Dsorg":"PS"}`), &ds); err != nil {
+		t.Fatalf("makeDataset: %v", err)
+	}
+	return ds
+}
+
+// TestLsCmd_Table verifies the table output contains the header and the dataset name.
+func TestLsCmd_Table(t *testing.T) {
+	fake := &fakeClient{
+		datasets: []hfs.InfoDataset{makeDataset(t)},
+	}
+	env := map[string]string{"ZFTP_PASSWORD": "pw"}
+	out, err := runCLI(t, fake, env, "ls", "USER.*", "-H", "h", "-u", "me")
+	if err != nil {
+		t.Fatalf("ls error: %v", err)
+	}
+	if !strings.Contains(out, "NAME") {
+		t.Errorf("output missing table header, got: %s", out)
+	}
+	if !strings.Contains(out, "USER.DATA") {
+		t.Errorf("output missing dataset name, got: %s", out)
+	}
+	// Verify ListDatasets was called with the pattern argument.
+	found := false
+	for _, c := range fake.calls {
+		if c == "ListDatasets:USER.*" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("ListDatasets:USER.* not in calls %v", fake.calls)
+	}
+}
+
+// TestLsCmd_JSON verifies the JSON output decodes to a non-empty array and that
+// Close was called (deferred cleanup).
+func TestLsCmd_JSON(t *testing.T) {
+	fake := &fakeClient{
+		datasets: []hfs.InfoDataset{makeDataset(t)},
+	}
+	env := map[string]string{"ZFTP_PASSWORD": "pw"}
+	out, err := runCLI(t, fake, env, "ls", "USER.*", "-H", "h", "-u", "me", "--json")
+	if err != nil {
+		t.Fatalf("ls --json error: %v", err)
+	}
+	var arr []json.RawMessage
+	if jsonErr := json.Unmarshal([]byte(out), &arr); jsonErr != nil {
+		t.Fatalf("output is not valid JSON array: %v\noutput: %s", jsonErr, out)
+	}
+	if len(arr) == 0 {
+		t.Errorf("expected non-empty JSON array, got: %s", out)
+	}
+	// Verify Close was called.
+	found := false
+	for _, c := range fake.calls {
+		if c == "Close" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Close not in calls %v", fake.calls)
+	}
+}

--- a/cli/internal/cmd/mutate.go
+++ b/cli/internal/cmd/mutate.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+package cmd
+
+import "github.com/spf13/cobra"
+
+// withClient runs fn against a freshly dialed session, closing it after.
+func withClient(d deps, g *globalFlags, fn func(c client) error) error {
+	c, err := dial(d, g)
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+	return fn(c)
+}
+
+// newRmCmd returns the rm subcommand that deletes a dataset or HFS file.
+func newRmCmd(d deps, g *globalFlags) *cobra.Command {
+	return &cobra.Command{
+		Use: "rm <path>", Short: "Delete a dataset or file (DELE)", Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, a []string) error {
+			return withClient(d, g, func(c client) error { return c.Delete(a[0]) })
+		},
+	}
+}
+
+// newMkdirCmd returns the mkdir subcommand that creates an HFS directory.
+func newMkdirCmd(d deps, g *globalFlags) *cobra.Command {
+	return &cobra.Command{
+		Use: "mkdir <path>", Short: "Create a directory (MKD)", Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, a []string) error {
+			return withClient(d, g, func(c client) error { return c.Mkdir(a[0]) })
+		},
+	}
+}
+
+// newMvCmd returns the mv subcommand that renames a dataset or HFS file.
+func newMvCmd(d deps, g *globalFlags) *cobra.Command {
+	return &cobra.Command{
+		Use: "mv <from> <to>", Short: "Rename a dataset or file (RNFR/RNTO)", Args: cobra.ExactArgs(2),
+		RunE: func(_ *cobra.Command, a []string) error {
+			return withClient(d, g, func(c client) error { return c.Rename(a[0], a[1]) })
+		},
+	}
+}
+
+// newChmodCmd returns the chmod subcommand that changes HFS permissions.
+func newChmodCmd(d deps, g *globalFlags) *cobra.Command {
+	return &cobra.Command{
+		Use: "chmod <mode> <path>", Short: "Change HFS permissions (SITE CHMOD)", Args: cobra.ExactArgs(2),
+		RunE: func(_ *cobra.Command, a []string) error {
+			return withClient(d, g, func(c client) error { return c.Chmod(a[0], a[1]) })
+		},
+	}
+}

--- a/cli/internal/cmd/mutate_test.go
+++ b/cli/internal/cmd/mutate_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestRmCmd(t *testing.T) {
+	fake := &fakeClient{}
+	env := map[string]string{"ZFTP_PASSWORD": "pw"}
+	_, err := runCLI(t, fake, env, "rm", "USER.A", "-H", "h", "-u", "me")
+	if err != nil {
+		t.Fatalf("rm error: %v", err)
+	}
+	want := "Delete:USER.A"
+	found := false
+	for _, c := range fake.calls {
+		if c == want {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("%s not in calls %v", want, fake.calls)
+	}
+	foundClose := false
+	for _, c := range fake.calls {
+		if c == "Close" {
+			foundClose = true
+		}
+	}
+	if !foundClose {
+		t.Errorf("Close not in calls %v", fake.calls)
+	}
+}
+
+func TestMkdirCmd(t *testing.T) {
+	fake := &fakeClient{}
+	env := map[string]string{"ZFTP_PASSWORD": "pw"}
+	_, err := runCLI(t, fake, env, "mkdir", "/u/x", "-H", "h", "-u", "me")
+	if err != nil {
+		t.Fatalf("mkdir error: %v", err)
+	}
+	want := "Mkdir:/u/x"
+	found := false
+	for _, c := range fake.calls {
+		if c == want {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("%s not in calls %v", want, fake.calls)
+	}
+}
+
+func TestMvCmd(t *testing.T) {
+	fake := &fakeClient{}
+	env := map[string]string{"ZFTP_PASSWORD": "pw"}
+	_, err := runCLI(t, fake, env, "mv", "A", "B", "-H", "h", "-u", "me")
+	if err != nil {
+		t.Fatalf("mv error: %v", err)
+	}
+	want := "Rename:A->B"
+	found := false
+	for _, c := range fake.calls {
+		if c == want {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("%s not in calls %v", want, fake.calls)
+	}
+}
+
+func TestChmodCmd(t *testing.T) {
+	fake := &fakeClient{}
+	env := map[string]string{"ZFTP_PASSWORD": "pw"}
+	_, err := runCLI(t, fake, env, "chmod", "750", "/u/f", "-H", "h", "-u", "me")
+	if err != nil {
+		t.Fatalf("chmod error: %v", err)
+	}
+	want := "Chmod:750 /u/f"
+	found := false
+	for _, c := range fake.calls {
+		if c == want {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("%s not in calls %v", want, fake.calls)
+	}
+}
+
+func TestMutateCmd_Error(t *testing.T) {
+	fake := &fakeClient{err: errors.New("denied")}
+	env := map[string]string{"ZFTP_PASSWORD": "pw"}
+	_, err := runCLI(t, fake, env, "rm", "USER.A", "-H", "h", "-u", "me")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "denied") {
+		t.Errorf("expected 'denied' in error, got: %v", err)
+	}
+}

--- a/cli/internal/cmd/put.go
+++ b/cli/internal/cmd/put.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+package cmd
+
+import (
+	"errors"
+	"path"
+
+	"github.com/spf13/cobra"
+)
+
+// newPutCmd returns the "put" sub-command (STOR). It uploads a local file to a
+// remote dataset or path, with optional byte-offset resume.
+func newPutCmd(d deps, g *globalFlags) *cobra.Command {
+	var ascii bool
+	var offset int64
+	c := &cobra.Command{
+		Use:   "put <local> [remote]",
+		Short: "Upload a file or dataset (STOR)",
+		Args:  cobra.RangeArgs(1, 2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			local := args[0]
+			remote := path.Base(local)
+			if len(args) == 2 {
+				remote = args[1]
+			}
+			if ascii && offset > 0 {
+				return errors.New("--offset is binary-only; ASCII resume is unsupported")
+			}
+			conn, err := dial(d, g)
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+			mode := transferType(ascii)
+			if offset > 0 {
+				return conn.PutAt(local, remote, mode, offset)
+			}
+			return conn.Put(local, remote, mode)
+		},
+	}
+	c.Flags().BoolVar(&ascii, "ascii", false, "ASCII (text) transfer; default is binary")
+	c.Flags().Int64Var(&offset, "offset", 0, "resume at byte offset (binary only)")
+	return c
+}

--- a/cli/internal/cmd/put_test.go
+++ b/cli/internal/cmd/put_test.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPut(t *testing.T) {
+	env := map[string]string{
+		"ZFTP_HOST": "localhost",
+		"ZFTP_USER": "user",
+	}
+
+	t.Run("put local remote", func(t *testing.T) {
+		fake := &fakeClient{}
+		_, err := runCLI(t, fake, env, "put", "local", "REMOTE")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := "Put:local->REMOTE"
+		if !contains(fake.calls, want) {
+			t.Errorf("calls %v does not contain %q", fake.calls, want)
+		}
+	})
+
+	t.Run("offset", func(t *testing.T) {
+		fake := &fakeClient{}
+		_, err := runCLI(t, fake, env, "put", "--offset", "100", "local", "REMOTE")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := "PutAt:local"
+		if !contains(fake.calls, want) {
+			t.Errorf("calls %v does not contain %q", fake.calls, want)
+		}
+	})
+
+	t.Run("ascii+offset rejected before dial", func(t *testing.T) {
+		fake := &fakeClient{}
+		_, err := runCLI(t, fake, env, "put", "--ascii", "--offset", "100", "local", "REMOTE")
+		if err == nil {
+			t.Fatal("expected error for --ascii --offset, got nil")
+		}
+		for _, c := range fake.calls {
+			if strings.HasPrefix(c, "PutAt:") {
+				t.Errorf("PutAt was called despite rejection: calls=%v", fake.calls)
+			}
+		}
+	})
+
+	t.Run("default remote basename", func(t *testing.T) {
+		fake := &fakeClient{}
+		_, err := runCLI(t, fake, env, "put", "/some/path/myfile.txt")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := "Put:/some/path/myfile.txt->myfile.txt"
+		if !contains(fake.calls, want) {
+			t.Errorf("calls %v does not contain %q", fake.calls, want)
+		}
+	})
+}

--- a/cli/internal/cmd/stat.go
+++ b/cli/internal/cmd/stat.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+package cmd
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+// newStatCmd returns the stat subcommand that reports system and server status.
+func newStatCmd(d deps, g *globalFlags) *cobra.Command {
+	return &cobra.Command{
+		Use:   "stat",
+		Short: "Show z/OS system info and server status snapshot",
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return withClient(d, g, func(c client) error {
+				sys, err := c.System()
+				if err != nil {
+					return err
+				}
+				info := map[string]any{"system": sys}
+				// StatusOf may return nil (fake or unsupported) — guard every call.
+				if st := c.StatusOf(); st != nil {
+					if ft, e := st.FileType(); e == nil {
+						info["fileType"] = ft
+					}
+				}
+				return emit(d, g.jsonOut, info, func(w io.Writer) {
+					fmt.Fprintln(w, sys)
+				})
+			})
+		},
+	}
+}

--- a/cli/internal/cmd/stat_test.go
+++ b/cli/internal/cmd/stat_test.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+package cmd
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestStatCmd_Table(t *testing.T) {
+	fake := &fakeClient{system: "MVS is the operating system of this server"}
+	env := map[string]string{"ZFTP_PASSWORD": "pw"}
+	out, err := runCLI(t, fake, env, "stat", "-H", "h", "-u", "me")
+	if err != nil {
+		t.Fatalf("stat error: %v", err)
+	}
+	if !strings.Contains(out, "MVS") {
+		t.Errorf("output missing system string, got: %s", out)
+	}
+}
+
+func TestStatCmd_JSON(t *testing.T) {
+	fake := &fakeClient{system: "MVS is the operating system of this server"}
+	env := map[string]string{"ZFTP_PASSWORD": "pw"}
+	out, err := runCLI(t, fake, env, "stat", "--json", "-H", "h", "-u", "me")
+	if err != nil {
+		t.Fatalf("stat --json error: %v", err)
+	}
+	var obj map[string]any
+	if jsonErr := json.Unmarshal([]byte(out), &obj); jsonErr != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput: %s", jsonErr, out)
+	}
+	if _, ok := obj["system"]; !ok {
+		t.Errorf("JSON output missing 'system' key, got: %s", out)
+	}
+}

--- a/cli/internal/cmd/version.go
+++ b/cli/internal/cmd/version.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+package cmd
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+// newVersionCmd returns the "version" subcommand, which prints build metadata.
+func newVersionCmd(d deps, bi BuildInfo) *cobra.Command {
+	var jsonOut bool
+	c := &cobra.Command{
+		Use:   "version",
+		Short: "Print version, commit, and build date",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return emit(d, jsonOut, bi, func(w io.Writer) {
+				fmt.Fprintf(w, "zftp %s (commit %s, built %s)\n", bi.Version, bi.Commit, bi.Date)
+			})
+		},
+	}
+	c.Flags().BoolVar(&jsonOut, "json", false, "JSON output")
+	return c
+}

--- a/cli/internal/cmd/version_test.go
+++ b/cli/internal/cmd/version_test.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestVersionCmd_Plain verifies the plain-text output contains the version string.
+func TestVersionCmd_Plain(t *testing.T) {
+	var buf bytes.Buffer
+	d := deps{
+		connect: nil,
+		getenv:  func(string) string { return "" },
+		prompt:  func() (string, error) { return "", nil },
+		out:     &buf,
+		errOut:  &buf,
+	}
+	root := newRootCmd(d, BuildInfo{Version: "2.0.0", Commit: "abc", Date: "d"})
+	root.SetArgs([]string{"version"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(buf.String(), "2.0.0") {
+		t.Fatalf("plain output %q does not contain 2.0.0", buf.String())
+	}
+}
+
+// TestVersionCmd_JSON verifies the JSON output contains the Version field with the correct value.
+func TestVersionCmd_JSON(t *testing.T) {
+	var buf bytes.Buffer
+	d := deps{
+		connect: nil,
+		getenv:  func(string) string { return "" },
+		prompt:  func() (string, error) { return "", nil },
+		out:     &buf,
+		errOut:  &buf,
+	}
+	root := newRootCmd(d, BuildInfo{Version: "2.0.0", Commit: "abc", Date: "d"})
+	root.SetArgs([]string{"version", "--json"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	got := buf.String()
+	if !strings.Contains(got, `"Version"`) {
+		t.Fatalf("JSON output %q does not contain key \"Version\"", got)
+	}
+	if !strings.Contains(got, "2.0.0") {
+		t.Fatalf("JSON output %q does not contain 2.0.0", got)
+	}
+}

--- a/cli/main.go
+++ b/cli/main.go
@@ -1,32 +1,25 @@
 // SPDX-License-Identifier: Apache-2.0
 
-// Command zftp is a (skeleton) command-line client built on the
-// gopkg.in/ro-ag/zftp.v2 library. It lives in its own module so the library
-// itself stays dependency-free; the full CLI (subcommands + release binaries) is
-// tracked separately.
+// Command zftp is the command-line client for the zftp z/OS FTP library.
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 
-	zftp "gopkg.in/ro-ag/zftp.v2"
+	"github.com/ro-ag/zftp/cli/internal/cmd"
 )
 
-// version is overwritten at release time via -ldflags "-X main.version=...".
-var version = "0.0.0-dev"
+// Injected by GoReleaser ldflags: -X main.version / main.commit / main.date.
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
 
 func main() {
-	showVersion := flag.Bool("version", false, "print version and exit")
-	flag.Parse()
-
-	if *showVersion {
-		fmt.Printf("zftp %s\n", version)
-		return
+	if err := cmd.Execute(cmd.BuildInfo{Version: version, Commit: commit, Date: date}); err != nil {
+		fmt.Fprintln(os.Stderr, "zftp:", err)
+		os.Exit(1)
 	}
-
-	fmt.Fprintln(os.Stderr, "zftp: command-line client for the z/OS FTP library gopkg.in/ro-ag/zftp.v2 (skeleton)")
-	fmt.Fprintf(os.Stderr, "default transfer type: %s\n", zftp.TypeBinary.Name())
-	fmt.Fprintln(os.Stderr, "the full CLI is not built yet; run with -version for the build version.")
 }


### PR DESCRIPTION
Closes #79

A full cobra CLI in `cli/` over the hardened v2 library. Every command is a pure unit under test: all external effects (dial+auth, stdout, password prompt, env) are injected through a `deps` struct, so commands run against a fake `client` with no socket.

## Commands
version · ls (datasets / `--pds` / `--hfs`) · get (`--ascii`/`--gzip`/`--offset`) · put (`--ascii`/`--offset`) · rm · mkdir · mv · chmod · stat · submit · jobs · job · job purge. Human tables via `text/tabwriter`, machine output via `--json`.

## Auth & deps
Password from `ZFTP_PASSWORD` env or interactive no-echo prompt — never a flag. Library stays passive-only (no active-mode flag). CLI deps: cobra + golang.org/x/term only.

## Tests
`cli/internal/cmd` is **82.6%** statement-covered (≥80% gate) via the injected `deps`/`fakeClient` seam — real-behavior tests only (no socket, no forced-coverage of production adapters).

## Gate
cli: build / vet / staticcheck / `go test -race -cover` (82.6%) / govulncheck — all green. Library unchanged and green.

> Homebrew/Docker/GitHub-Releases install and the signed multi-arch binaries arrive with the release pipeline (PR C). PR B of A/B/C.