### PR TITLE
build: GoReleaser release pipeline (multi-arch, SBOM, cosign, Docker, Homebrew)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write   # create the GitHub Release
+  packages: write   # push to GHCR
+  id-token: write   # cosign keyless (OIDC)
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: stable
+      - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      - name: Login to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+      - uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+      - uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
+        with:
+          version: "~> v2"
+          args: "release --clean"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dummy/
 /cli/cli
 /cli/zftp
 /zftp
+/dist/
 *.exe
 
 # Test and coverage artifacts

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,78 @@
+version: 2
+project_name: zftp
+
+builds:
+  - id: zftp
+    dir: cli
+    main: .
+    binary: zftp
+    env: [CGO_ENABLED=0]
+    flags: [-trimpath]
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
+    goos: [linux, darwin, windows]
+    goarch: [amd64, arm64]
+
+archives:
+  - formats: [tar.gz]
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+
+checksum:
+  name_template: "checksums.txt"
+
+sboms:
+  - artifacts: archive
+
+signs:
+  - cmd: cosign
+    certificate: "${artifact}.pem"
+    args:
+      - sign-blob
+      - "--output-certificate=${certificate}"
+      - "--output-signature=${signature}"
+      - "${artifact}"
+      - "--yes"
+    artifacts: checksum
+    output: true
+
+dockers_v2:
+  - images:
+      - "ghcr.io/ro-ag/zftp"
+    tags:
+      - "{{ .Version }}"
+      - "latest"
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    dockerfile: "Dockerfile"
+    labels:
+      org.opencontainers.image.version: "{{ .Version }}"
+
+homebrew_casks:
+  - name: zftp
+    binaries:
+      - zftp
+    repository:
+      owner: ro-ag
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    homepage: "https://github.com/ro-ag/zftp"
+    description: "Pure-Go z/OS FTP client"
+
+changelog:
+  sort: asc
+  groups:
+    - { title: Features, regexp: '^feat', order: 0 }
+    - { title: Fixes, regexp: '^fix', order: 1 }
+    - { title: Others, order: 999 }
+  filters:
+    exclude: ['^docs', '^test', '^chore', '^ci', 'Merge pull request']
+
+release:
+  github: { owner: ro-ag, name: zftp }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM gcr.io/distroless/static:nonroot
+COPY zftp /usr/bin/zftp
+ENTRYPOINT ["/usr/bin/zftp"]

--- a/Readme.md
+++ b/Readme.md
@@ -2,6 +2,7 @@
 
 [![Go Reference](https://pkg.go.dev/badge/gopkg.in/ro-ag/zftp.v2.svg)](https://pkg.go.dev/gopkg.in/ro-ag/zftp.v2)
 [![CI](https://github.com/ro-ag/zftp/actions/workflows/ci.yml/badge.svg)](https://github.com/ro-ag/zftp/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/ro-ag/zftp)](https://github.com/ro-ag/zftp/releases/latest)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](./LICENSE)
 
 A **pure-Go FTP client specialized for IBM z/OS mainframes** — datasets, JES
@@ -15,6 +16,55 @@ go get gopkg.in/ro-ag/zftp.v2
 > v2 is the current line. It is a clean, SemVer-correct break from v1: the public
 > API returns concrete types instead of interfaces. Existing v1 tags are
 > unaffected.
+
+## Install (CLI binary)
+
+The `zftp` command-line client is distributed as a prebuilt binary via GitHub
+Releases, Homebrew, and Docker. A tag-triggered release workflow builds
+multi-platform archives, a multi-arch Docker image on GHCR, and a Homebrew cask.
+
+### GitHub Releases
+
+Download the archive for your OS/arch from the
+[Releases page](https://github.com/ro-ag/zftp/releases/latest) and extract
+the `zftp` binary:
+
+```bash
+# archives are named zftp_<version>_<os>_<arch>.tar.gz
+# os: linux|darwin|windows   arch: amd64|arm64   (.zip on windows)
+VERSION=2.0.0
+curl -L https://github.com/ro-ag/zftp/releases/download/v${VERSION}/zftp_${VERSION}_linux_amd64.tar.gz \
+  | tar -xz zftp
+sudo mv zftp /usr/local/bin/
+```
+
+### Homebrew
+
+```bash
+brew tap ro-ag/tap        # only needed the first time
+brew install --cask ro-ag/tap/zftp
+```
+
+The tap publishes a **cask** that installs the prebuilt binary — no build from
+source.
+
+### Docker
+
+```bash
+docker run --rm ghcr.io/ro-ag/zftp:latest version
+```
+
+The image is multi-arch (amd64/arm64) and hosted on GHCR.
+
+### go install (development builds only)
+
+```bash
+go install github.com/ro-ag/zftp/cli@latest
+```
+
+> **Note:** `cli/` uses a `replace` directive pointing to `../` for the
+> library, so `go install` from a clean module checkout is not wired yet.
+> For production use, prefer the release binaries, Homebrew, or Docker above.
 
 ## Features
 
@@ -152,8 +202,8 @@ Integration tests that require a live host are skipped unless `ZFTP_HOSTNAME`,
 ## Command-line client
 
 A CLI built on this library lives in [`cli/`](./cli) as a separate module, which
-keeps the library itself dependency-free. It is currently a skeleton; the full
-client and downloadable binaries are planned.
+keeps the library itself dependency-free. See the [Install](#install-cli-binary)
+section above for prebuilt binaries, Homebrew, and Docker.
 
 ## Contributing
 


### PR DESCRIPTION
Closes #81

Ships the signed, SBOM'd, multi-OS/arch release pipeline for the zftp binary.

## What's here
- `.goreleaser.yaml` (v2): 6 os/arch builds (linux/darwin/windows × amd64/arm64), tar.gz/zip archives, `checksums.txt`, syft SBOMs, **cosign keyless** signing of the checksum, multi-arch **GHCR** image (`dockers_v2`, version+latest), **Homebrew** tap cask (`homebrew_casks`). (Modernized off the now-deprecated `brews`/`dockers`/`docker_manifests` keys.)
- `Dockerfile`: distroless static nonroot.
- `.github/workflows/release.yml`: tag-triggered (`v*`), every action SHA-pinned (matches ci.yml style), `release --clean`.
- `dist/` gitignored; Readme.md install section + release badge.

## Verified (dry run — nothing published)
- `goreleaser check` → exit 0.
- `goreleaser release --snapshot --clean --skip=sign,docker,publish` → 6 archives + 6 `.sbom.json` + `checksums.txt`.
- `actionlint .github/workflows/release.yml` → clean.

## ⚠️ Prerequisites before any tag (maintainer actions)
- Create repo `ro-ag/homebrew-tap`.
- Add repo secret `HOMEBREW_TAP_GITHUB_TOKEN` (a PAT with `repo` scope on the tap).
- GHCR uses the built-in `GITHUB_TOKEN`; cosign keyless needs no secret (OIDC `id-token`).
- Submodule caveat: goreleaser builds `cli/` against the co-checked-out library via the `../` replace (works in CI at the tag). `go install github.com/ro-ag/zftp/cli@latest` from a clean checkout would additionally need the replace dropped + a `cli/` module tag — out of scope for the binary release.

## Held
Tagging `v2.0.0` fires this workflow and publishes artifacts — **do not tag without explicit go-ahead**. The first release tag should be `v2.0.0` so asset names match the README.

PR C of A/B/C (library → CLI → release pipeline).