### PR TITLE
chore: gofmt test file; verify go mod tidy clean

### DIFF
--- a/hfs/spool_robust_test.go
+++ b/hfs/spool_robust_test.go
@@ -86,10 +86,10 @@ func TestParseInfoJobDetail_StrayBlankLine(t *testing.T) {
 // filtered out.
 func TestParseInfoJob_ErrorReportsOriginalLine(t *testing.T) {
 	records := []string{
-		"",                                        // line 1
-		"",                                        // line 2
+		"", // line 1
+		"", // line 2
 		"GOODJOB  JOB00001 OUTPUT  3 spool files", // line 3
-		"BADRECORD",                               // line 4 (malformed)
+		"BADRECORD", // line 4 (malformed)
 	}
 	_, err := hfs.ParseInfoJob(records)
 	if err == nil {


### PR DESCRIPTION
Pre-v2.0.0 housekeeping.

- `gofmt -w hfs/spool_robust_test.go` — re-aligns trailing comments (gofmt 1.26).
- `go mod tidy` run on root and `cli/` modules: **no changes** (both already tidy).
- Verified: `go build ./...`, `go vet ./...` (root) and `cli` build all green.

Clears the tree before tagging the v2 release.