### PR TITLE
ci: fix cosign bundle signing; disable brew cask publish

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,11 +31,11 @@ sboms:
 
 signs:
   - cmd: cosign
-    certificate: "${artifact}.pem"
+    signature: "${artifact}.bundle"
     args:
       - sign-blob
-      - "--output-certificate=${certificate}"
-      - "--output-signature=${signature}"
+      - "--new-bundle-format"
+      - "--bundle=${signature}"
       - "${artifact}"
       - "--yes"
     artifacts: checksum
@@ -55,7 +55,10 @@ dockers_v2:
       org.opencontainers.image.version: "{{ .Version }}"
 
 homebrew_casks:
+  # Disabled until the HOMEBREW_TAP_GITHUB_TOKEN secret is configured.
+  # skip_upload still builds the cask locally but does not push to the tap.
   - name: zftp
+    skip_upload: "true"
     binaries:
       - zftp
     repository:


### PR DESCRIPTION
## Problem
`v2.0.0-rc.1` release run [failed](https://github.com/ro-ag/zftp/actions/runs/28075366372) at the cosign signing step:
```
signing dist/checksums.txt: create bundle file: open : no such file or directory
could not sign artifact cmd=cosign artifact=checksums.txt
```
GoReleaser v2.16.0 ships a cosign that defaults to `--new-bundle-format`, which **ignores** `--output-signature`/`--output-certificate` and needs `--bundle` — never passed → empty bundle path → crash. Binaries/archives/checksums all built fine; it died before sbom/docker/release/brew.

## Fix
- **cosign** → modern bundle format: emit a single `${artifact}.bundle` (cert + signature + rekor) instead of the deprecated `.sig` + `.pem` pair.
- **homebrew cask** → `skip_upload: "true"`: `HOMEBREW_TAP_GITHUB_TOKEN` secret is not set, so the tap push would fail next. Cask still generated, just not published.

## Validation
`goreleaser v2.16.0` (same as CI): `goreleaser check` passes; `--snapshot` build produced all 6 archives + checksums + cask locally. Signing itself runs only in CI (keyless OIDC).

After merge: retag `v2.0.0-rc.1` on the fixed commit to re-trigger the release.