### PR TITLE
ci: fix Dockerfile COPY for dockers_v2 multi-arch context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
 FROM gcr.io/distroless/static:nonroot
-COPY zftp /usr/bin/zftp
+# GoReleaser dockers_v2 lays the build context out as <os>/<arch>/<binary>,
+# so the per-platform binary must be copied via the buildx $TARGETPLATFORM arg.
+ARG TARGETPLATFORM
+COPY $TARGETPLATFORM/zftp /usr/bin/zftp
 ENTRYPOINT ["/usr/bin/zftp"]


### PR DESCRIPTION
## Problem
`v2.0.0-rc.1` got past signing this run but [failed](https://github.com/ro-ag/zftp/actions/runs/28075730627) at the docker step:
```
could not build docker image id=zftp
ERROR: failed to compute cache key: "/zftp": not found (Dockerfile:2)
```

## Cause
GoReleaser `dockers_v2` assembles the buildx context as `<os>/<arch>/<binary>`:
```
context/
├── Dockerfile
├── linux/amd64/zftp
└── linux/arm64/zftp
```
The Dockerfile's `COPY zftp ...` looked at the context root, which has no bare `zftp`.

## Fix
Use the buildx-provided `$TARGETPLATFORM` arg so each architecture copies its own binary:
```dockerfile
ARG TARGETPLATFORM
COPY $TARGETPLATFORM/zftp /usr/bin/zftp
```
Per the [dockers_v2 docs](https://goreleaser.com/customization/dockers_v2/). Multi-arch docker build runs only in CI (needs buildx+qemu), so it's validated on the retag.

After merge: retag `v2.0.0-rc.1` to re-trigger.