### PR TITLE
ci: auto-flag prereleases and guard docker :latest

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -46,7 +46,8 @@ dockers_v2:
       - "ghcr.io/ro-ag/zftp"
     tags:
       - "{{ .Version }}"
-      - "latest"
+      # Only the stable release should claim :latest; prereleases (rc/beta) skip it.
+      - "{{ if not .Prerelease }}latest{{ end }}"
     platforms:
       - linux/amd64
       - linux/arm64
@@ -79,3 +80,6 @@ changelog:
 
 release:
   github: { owner: ro-ag, name: zftp }
+  # auto = flag as a GitHub pre-release when the tag carries a semver
+  # prerelease suffix (e.g. v2.0.0-rc.1); stable tags publish as full releases.
+  prerelease: auto


### PR DESCRIPTION
Follow-up polish from the v2.0.0-rc.1 dry run. The pipeline is green; these two gaps showed up in how the RC published.

## Changes
- **`release.prerelease: auto`** — GoReleaser defaults this *off*, so `v2.0.0-rc.1` published as a full 'Latest' release. With `auto`, any tag carrying a semver prerelease suffix is flagged as a GitHub pre-release; stable tags stay full releases. (rc.1's flag was already corrected manually.)
- **docker `:latest` guard** — `{{ if not .Prerelease }}latest{{ end }}` so RCs no longer claim `:latest`. The next stable `v2.0.0` will set `:latest` correctly.

Homebrew stays disabled (`skip_upload`) per decision — `HOMEBREW_TAP_GITHUB_TOKEN` still unset.

Validated with `goreleaser check` (v2.16.0). No final tag cut — that's a separate step.