### PR TITLE
harden control/transfer paths and polish the v2 API surface

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -132,9 +132,9 @@ A compile-checked version of this snippet lives in
 - `(*FTPSession) Login(user, pass string) error`
 - `(*FTPSession) Get(remote, local string, mode TransferType) error` /
   `Put(local, remote string, mode TransferType, a ...DataSpec) error`
-- `(*FTPSession) RetrieveIO(remote string, w io.Writer, mode TransferType)` /
-  `StoreIO(remote string, r io.Reader, mode TransferType)` — stream without
-  touching the local filesystem.
+- `(*FTPSession) RetrieveIO(remote string, w io.Writer, mode TransferType) (int64, error)` /
+  `StoreIO(remote string, r io.Reader, mode TransferType) (int64, error)` — stream
+  without touching the local filesystem.
 - `(*FTPSession) ListDatasets(pattern string) ([]hfs.InfoDataset, error)`
 - `(*FTPSession) ListPds(pattern string) ([]hfs.InfoPdsMember, error)`
 - `(*FTPSession) ListSpool(pattern string) ([]hfs.InfoJob, error)`

--- a/cli/internal/cmd/cmd.go
+++ b/cli/internal/cmd/cmd.go
@@ -45,6 +45,10 @@ type client interface {
 	Close() error
 }
 
+// *zftp.FTPSession satisfies client; enforce it at compile time so library API
+// drift surfaces here rather than only at the realConnect call site.
+var _ client = (*zftp.FTPSession)(nil)
+
 // connOpts carries the resolved connection parameters for the connect factory.
 type connOpts struct {
 	host, port       string

--- a/cli/internal/cmd/jes.go
+++ b/cli/internal/cmd/jes.go
@@ -62,8 +62,10 @@ func newJobsCmd(d deps, g *globalFlags) *cobra.Command {
 // newJobCmd returns the job subcommand that shows a job's status/detail and
 // hosts the job purge subcommand.
 //
-// Fix 1: InfoJob has no .String() on the struct value — call fields explicitly.
-// Fix 2: emit jd.Job() (InfoJob, exported fields) not jd (*InfoJobDetail, unexported).
+// It emits jd.Job() (InfoJob, exported json-tagged fields) rather than jd
+// (*InfoJobDetail, unexported fields) so --json yields a real object. InfoJob and
+// its FieldString fields marshal/stringify by value, so the value passed to emit
+// renders correctly without taking its address.
 func newJobCmd(d deps, g *globalFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "job <id>",
@@ -77,9 +79,8 @@ func newJobCmd(d deps, g *globalFlags) *cobra.Command {
 				}
 				job := jd.Job()
 				// Emit job (InfoJob, exported json-tagged fields) for JSON so the
-				// output is a real object rather than {}. For the human render,
-				// print the fields explicitly — InfoJob.String() exists only as a
-				// pointer receiver (*InfoJob) and is not called on the value here.
+				// output is a real object. The human render prints the fields
+				// explicitly for column control.
 				return emit(d, g.jsonOut, job, func(w io.Writer) {
 					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
 						job.Name.String(), job.JobId.String(),

--- a/cmd.go
+++ b/cmd.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"gopkg.in/ro-ag/zftp.v2/internal/log"
 	"gopkg.in/ro-ag/zftp.v2/internal/utils"
+	"net"
 	"strings"
 	"time"
 )
@@ -98,14 +99,27 @@ func parseCommand(lg *log.Logger, cmd string, a ...string) []byte {
 		lg.Commandf("%s", command)
 	}
 
-	fullCommand := fmt.Appendf(nil, "%s %s\r\n", command, args)
+	var fullCommand []byte
+	if args == "" {
+		// No arguments: emit "verb\r\n" with no trailing space (e.g. "NOOP\r\n").
+		fullCommand = fmt.Appendf(nil, "%s\r\n", command)
+	} else {
+		fullCommand = fmt.Appendf(nil, "%s %s\r\n", command, args)
+	}
 
 	return fullCommand
 }
 
-// SendCommand sends a command to the FTP server and expects a specific return code. It uses a default context.
+// SendCommand sends a command to the FTP server and expects a specific return
+// code. The whole round-trip is bounded by the session's reply timeout (see
+// WithReplyTimeout, default 120s) so a server that accepts a command but never
+// replies cannot hang the caller forever; on expiry the control stream is
+// considered unrecoverable and the session is closed. Use SendCommandWithContext
+// to supply a different deadline or cancellation.
 func (s *FTPSession) SendCommand(expect ReturnCode, command string, a ...string) (string, error) {
-	return s.SendCommandWithContext(context.Background(), expect, command, a...)
+	ctx, cancel := context.WithTimeout(context.Background(), s.dialCfg.replyTimeout())
+	defer cancel()
+	return s.SendCommandWithContext(ctx, expect, command, a...)
 }
 
 // CheckLast reads the server message buffer and validate the return code.
@@ -127,7 +141,9 @@ func (s *FTPSession) checkLast(expect ReturnCode, alsoAccept ...ReturnCode) (str
 
 	if s.isClosed.Load() {
 		s.log.Warningf("<%s> session %s is closed", utils.Caller(), s.conn.RemoteAddr().String())
-		return "", nil
+		// Never report a completion on a closed session: confirmData would otherwise
+		// treat a transfer whose terminal reply was never read as successful.
+		return "", net.ErrClosed
 	}
 
 	// Bound the reply read: z/OS sends the terminal 226/250 asynchronously to the
@@ -158,6 +174,13 @@ func (s *FTPSession) checkLast(expect ReturnCode, alsoAccept ...ReturnCode) (str
 				}
 			}
 			s.log.Serverf("[res|error] %s", err)
+			// A post-transfer reply whose code is not a completion code (e.g. 426
+			// "transfer aborted", which z/OS may follow with a second reply such as
+			// 226 acknowledging an ABOR) means the transfer did not end cleanly. Such
+			// replies can be multi-part, and FTP has no in-band way to resynchronize a
+			// partially-drained control stream, so close the session rather than leave
+			// a trailing reply buffered to desync ("shift") the next command.
+			s.closeLocked()
 			return "", err
 		}
 		s.log.Serverf("[res|error] %s", err)

--- a/codes.go
+++ b/codes.go
@@ -134,16 +134,15 @@ func (code ReturnCode) check(reader *bufio.Reader, lg *log.Logger) (msg string, 
 		line, isPrefix, err := reader.ReadLine()
 		if err != nil {
 			if err == io.EOF {
-				// EOF before any complete reply line means the peer closed the
-				// control stream mid-reply: an unrecoverable I/O failure, not a
-				// valid (if unexpected) FTP reply. Surface it as a plain error so
-				// callers close the desynchronized session instead of mistaking it
-				// for a ReturnError. If a complete reply was already read, fall
-				// through and let the code-mismatch logic below report it.
-				if !haveOpening {
-					return response.String(), io.ErrUnexpectedEOF
-				}
-				break
+				// Reaching EOF here means the stream ended before a terminator line
+				// (a real terminator breaks out of the loop below, so it never
+				// reaches this read). Whether or not an opening line was seen, the
+				// reply is truncated and the control stream is dead: surface it as a
+				// plain io.ErrUnexpectedEOF so callers close the desynchronized
+				// session instead of acting on a partial reply or mistaking it for a
+				// ReturnError. This holds even when the opening code equals the
+				// expected code, where the post-loop check would otherwise pass.
+				return response.String(), io.ErrUnexpectedEOF
 			}
 			return "", err
 		}

--- a/codes.go
+++ b/codes.go
@@ -99,6 +99,14 @@ func (e *ReturnError) Unwrap() error {
 	return e.cause
 }
 
+// Compile-time checks that *ReturnError implements error and the optional Is /
+// Unwrap interfaces the errors package looks for during errors.Is/errors.As.
+var (
+	_ error                       = (*ReturnError)(nil)
+	_ interface{ Is(error) bool } = (*ReturnError)(nil)
+	_ interface{ Unwrap() error } = (*ReturnError)(nil)
+)
+
 // CodeError returns an error usable only as an errors.Is target: it matches any
 // *ReturnError carrying the given FTP return code. External callers cannot build
 // a *ReturnError directly (its fields are unexported), so this is the supported

--- a/codes_eof_test.go
+++ b/codes_eof_test.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package zftp
+
+import (
+	"bufio"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"gopkg.in/ro-ag/zftp.v2/internal/log"
+)
+
+// M4: a multiline reply whose stream ends after the opening line but before the
+// terminator line is truncated — the control connection died mid-reply. check
+// must surface io.ErrUnexpectedEOF (so the caller closes the desynchronized
+// session) rather than returning the partial reply as a successful (nil) result,
+// even when the opening code equals the expected code.
+func TestCheck_EOFAfterOpeningLineIsError(t *testing.T) {
+	r := bufio.NewReader(strings.NewReader("220-line one\r\n220-line two\r\n"))
+	_, err := CodeSvcReadySoon.check(r, log.New(nil, log.None))
+	if err == nil {
+		t.Fatal("EOF after opening line returned nil: truncated reply reported as success")
+	}
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatalf("want io.ErrUnexpectedEOF, got %v", err)
+	}
+}
+
+// A complete single-line reply terminated normally must still succeed (guard that
+// the fix does not over-trigger on a clean terminator followed by EOF).
+func TestCheck_CompleteReplyStillSucceeds(t *testing.T) {
+	r := bufio.NewReader(strings.NewReader("220 service ready\r\n"))
+	msg, err := CodeSvcReadySoon.check(r, log.New(nil, log.None))
+	if err != nil {
+		t.Fatalf("complete reply returned error: %v", err)
+	}
+	if !strings.Contains(msg, "service ready") {
+		t.Fatalf("unexpected message: %q", msg)
+	}
+}

--- a/completion226_test.go
+++ b/completion226_test.go
@@ -20,7 +20,7 @@ func TestRetrieveIO_Accepts226Completion(t *testing.T) {
 	srv.CompletionReply("RETR", "226 closing data connection; transfer complete")
 
 	var buf bytes.Buffer
-	if _, _, err := s.RetrieveIO("MY.BIN", &buf, zftp.TypeBinary); err != nil {
+	if _, err := s.RetrieveIO("MY.BIN", &buf, zftp.TypeBinary); err != nil {
 		t.Fatalf("RetrieveIO with a 226 completion: %v", err)
 	}
 	if buf.String() != "payload-bytes" {
@@ -34,7 +34,7 @@ func TestStoreIO_Accepts226Completion(t *testing.T) {
 	s, srv := dialMock(t)
 	srv.CompletionReply("STOR", "226 closing data connection; transfer complete")
 
-	if _, _, err := s.StoreIO("OUT.BIN", strings.NewReader("data"), zftp.TypeBinary); err != nil {
+	if _, err := s.StoreIO("OUT.BIN", strings.NewReader("data"), zftp.TypeBinary); err != nil {
 		t.Fatalf("StoreIO with a 226 completion: %v", err)
 	}
 	if stored, ok := srv.Stored("OUT.BIN"); !ok || string(stored) != "data" {

--- a/data_conn_test.go
+++ b/data_conn_test.go
@@ -49,7 +49,7 @@ func TestRetrieve_SinkError_ClosesSession(t *testing.T) {
 	s, srv := dialMock(t)
 	srv.DataFor("RETR", "BIG.BIN", strings.Repeat("z", 64*1024))
 
-	if _, _, err := s.RetrieveIO("BIG.BIN", errWriter{}, zftp.TypeBinary); err == nil {
+	if _, err := s.RetrieveIO("BIG.BIN", errWriter{}, zftp.TypeBinary); err == nil {
 		t.Fatal("RetrieveIO with a failing sink must error, got nil")
 	}
 	if !s.IsClosed() {
@@ -130,7 +130,7 @@ func TestSession_ConcurrentRetrieveAndClose_NoPanic(t *testing.T) {
 		var wg sync.WaitGroup
 		wg.Go(func() {
 			var buf bytes.Buffer
-			_, _, _ = s.RetrieveIO("BIG.BIN", &buf, zftp.TypeBinary)
+			_, _ = s.RetrieveIO("BIG.BIN", &buf, zftp.TypeBinary)
 		})
 		wg.Go(func() {
 			_ = s.Close()

--- a/doc_coverage_test.go
+++ b/doc_coverage_test.go
@@ -7,22 +7,46 @@ import (
 	"go/parser"
 	"go/token"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"testing"
 )
 
 // TestExportedIdentifiersAreDocumented enforces that every exported identifier in
-// the zftp package's own source files carries a doc comment, so `go doc` is
-// complete for the public surface. It scans the package source directly (skipping
-// test files and generated files), and treats a const/var/field as documented if
-// it has a doc comment, a trailing line comment, or belongs to a documented
-// declaration block — matching what godoc renders.
+// the module's public packages carries a doc comment, so `go doc` is complete for
+// the public surface. It scans the root package plus the exported subpackages
+// (hfs, eol) directly (skipping test files and generated files), and treats a
+// const/var/field as documented if it has a doc comment, a trailing line comment,
+// or belongs to a documented declaration block — matching what godoc renders.
+// Findings are reported as "pkg/ident" (the root package uses "." as its label).
 func TestExportedIdentifiersAreDocumented(t *testing.T) {
+	// Directories of the module's exported packages, relative to the repo root.
+	// The doc gate must hold for every package a consumer can import.
+	dirs := []string{".", "hfs", "eol"}
+
+	var undocumented []string
+	for _, dir := range dirs {
+		undocumented = append(undocumented, undocumentedExportedIdents(t, dir)...)
+	}
+
+	if len(undocumented) > 0 {
+		sort.Strings(undocumented)
+		t.Fatalf("exported identifiers without a doc comment (%d):\n%s",
+			len(undocumented), strings.Join(undocumented, "\n"))
+	}
+}
+
+// undocumentedExportedIdents parses every non-test, non-generated .go file in dir
+// and returns the exported identifiers that lack documentation. Each finding is
+// prefixed with dir (the root package "." is reported as "."), e.g.
+// "hfs: type Dataset" or ".: func Dial".
+func undocumentedExportedIdents(t *testing.T, dir string) []string {
+	t.Helper()
 	fset := token.NewFileSet()
-	entries, err := os.ReadDir(".")
+	entries, err := os.ReadDir(dir)
 	if err != nil {
-		t.Fatalf("read package dir: %v", err)
+		t.Fatalf("read package dir %q: %v", dir, err)
 	}
 
 	var undocumented []string
@@ -31,13 +55,15 @@ func TestExportedIdentifiersAreDocumented(t *testing.T) {
 		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
 			continue
 		}
-		f, err := parser.ParseFile(fset, name, nil, parser.ParseComments)
+		path := filepath.Join(dir, name)
+		f, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
 		if err != nil {
-			t.Fatalf("parse %s: %v", name, err)
+			t.Fatalf("parse %s: %v", path, err)
 		}
 		if isGeneratedFile(f) {
 			continue
 		}
+		label := dir + ": "
 		for _, d := range f.Decls {
 			switch decl := d.(type) {
 			case *ast.FuncDecl:
@@ -51,22 +77,20 @@ func TestExportedIdentifiersAreDocumented(t *testing.T) {
 					}
 				}
 				if decl.Doc == nil {
-					undocumented = append(undocumented, name+": func "+funcLabel(decl))
+					undocumented = append(undocumented, label+"func "+funcLabel(decl))
 				}
 			case *ast.GenDecl:
-				collectUndocumentedGenDecl(name, decl, &undocumented)
+				collectUndocumentedGenDecl(label, decl, &undocumented)
 			}
 		}
 	}
-
-	if len(undocumented) > 0 {
-		sort.Strings(undocumented)
-		t.Fatalf("exported identifiers without a doc comment (%d):\n%s",
-			len(undocumented), strings.Join(undocumented, "\n"))
-	}
+	return undocumented
 }
 
-func collectUndocumentedGenDecl(file string, decl *ast.GenDecl, out *[]string) {
+// collectUndocumentedGenDecl appends undocumented exported types, struct fields,
+// and consts/vars from decl to out. label is the per-package prefix (e.g. "hfs: ")
+// already including its trailing separator.
+func collectUndocumentedGenDecl(label string, decl *ast.GenDecl, out *[]string) {
 	for _, spec := range decl.Specs {
 		switch s := spec.(type) {
 		case *ast.TypeSpec:
@@ -74,13 +98,13 @@ func collectUndocumentedGenDecl(file string, decl *ast.GenDecl, out *[]string) {
 				continue
 			}
 			if s.Doc == nil && decl.Doc == nil {
-				*out = append(*out, file+": type "+s.Name.Name)
+				*out = append(*out, label+"type "+s.Name.Name)
 			}
 			if st, ok := s.Type.(*ast.StructType); ok && st.Fields != nil {
 				for _, fld := range st.Fields.List {
 					for _, fn := range fld.Names {
 						if ast.IsExported(fn.Name) && fld.Doc == nil && fld.Comment == nil {
-							*out = append(*out, file+": field "+s.Name.Name+"."+fn.Name)
+							*out = append(*out, label+"field "+s.Name.Name+"."+fn.Name)
 						}
 					}
 				}
@@ -102,7 +126,7 @@ func collectUndocumentedGenDecl(file string, decl *ast.GenDecl, out *[]string) {
 				for _, n := range s.Names {
 					names = append(names, n.Name)
 				}
-				*out = append(*out, file+": value "+strings.Join(names, ","))
+				*out = append(*out, label+"value "+strings.Join(names, ","))
 			}
 		}
 	}

--- a/docs/v2-readiness-review.md
+++ b/docs/v2-readiness-review.md
@@ -1,0 +1,152 @@
+# zftp v2.0.0 — Release-Gate Review Findings
+
+Date: 2026-06-24. Status: **NOT ready to tag `v2.0.0`** — blockers + majors below.
+Gate baseline at review time: `go build`/`vet`/`staticcheck`/`govulncheck` clean, full
+`-race` suite green. All findings below are **latent** (existing tests do not catch them).
+
+Module path `gopkg.in/ro-ag/zftp.v2` is correct (gopkg.in `.v2` convention) — not a finding.
+
+Items M2/M4/M5/M7 are corroborated by a deep-research pass on z/OS FTP control-reply
+semantics (RFC 959 §4.2/§4.1.3/§5, IBM z/OS Comms Server; APAR PQ54076 confirms the
+RST-on-abort behavior behind M7).
+
+---
+
+## Resolution — branch `harden/v2-readiness` (2026-06-24)
+
+All work TDD (RED→GREEN), full gate green under `-race` (gofmt/build/vet/staticcheck/govulncheck + cli).
+
+| Item | Status |
+|------|--------|
+| B1 value receivers | **Fixed** — `Field*`/`Info*` `String`/`Value`/`MarshalJSON`/`IsOverflow` now value receivers; `job --json` verified. |
+| B2 `Detail() []JobDetail` | **Fixed** — `jobDetail`→`JobDetail` exported. |
+| M1 `TYPE \x00` | **Fixed** — `newSession` seeds `currType=TypeAscii`. |
+| M2 unbounded reads | **Fixed** — `SendCommand` bounded by reply timeout. |
+| M3 TLS data handshake | **Fixed** — `tlsHandshakeBounded` with deadline. |
+| M4 EOF-as-success | **Fixed** — `check` returns `io.ErrUnexpectedEOF` on EOF-before-terminator. |
+| M5 `checkLast` nil-on-closed | **Fixed** — returns `net.ErrClosed`. |
+| M6 JES abend | **Partial** — wrong docs corrected (verified ABAxxx=ABARS, not abend); spool-scan abend **matcher PARKED** pending a real-LPAR `$HASP395 ABEND=` capture (no-fabricate rule). |
+| M7 passive-abort desync | **Fixed** — `checkLast` closes the session on a non-completion (426) post-transfer reply. |
+| Minors | **Fixed**: doc-coverage gate extended to hfs/eol + ~48 idents documented; dead `utils` code + `StandardizeQuote` deleted; `parseCommand` trailing space; Login user hygiene; `TransferType(0).Name`→"UNKNOWN"; `eol.Cr` `// Deprecated:`; signal-handler + SITE-clobber documented. |
+| API-shape (deferred to user) | `(sz,msg,err)` triple on `*IO`; `ServerStatus` `Snapshot()`; `WithRecfmFB` naming; `GetUser`→`User`; `StatusOf`/`SetStatusOf` naming. Permanent at v2 — awaiting decision. |
+| cli `go install` | Unchanged — documented "dev builds only"; binary-first distribution. |
+
+---
+
+## BLOCKERS — fix before tag (permanent API lock-in / ships broken)
+
+- [ ] **B1. Pointer-receiver `String()` + `MarshalJSON` on every `hfs.Field*`/`Info*` type, but API returns value slices.**
+  Empirically proven: `json.Marshal(InfoJob value)` → `{"Name":{},...}` (non-addressable value
+  cannot dispatch a pointer-receiver `MarshalJSON`); pointer and slice marshal fine.
+  Symptoms: (a) `zftp job --json` ships emitting `{}` for every field
+  (`cli/internal/cmd/jes.go:83`); (b) `fmt.Println(datasets[0])` never calls `String()` —
+  value does not satisfy `fmt.Stringer`.
+  Fix: make `String()`/`MarshalJSON` **value receivers** on
+  `hfs/attributes.go` (FieldString/Int/Float/Date/Time: 28,36,97,120,176,187,232,243,276,287),
+  `hfs/dataset.go:113`, `hfs/partitioned.go:27`, `hfs/spool.go:54`. One change fixes both. Breaking-OK now.
+
+- [ ] **B2. `InfoJobDetail.Detail() []jobDetail` returns an unexported type** — `hfs/spool.go:171`.
+  External callers cannot name the type → per-step JES detail permanently unusable.
+  Fix: export `jobDetail` → `JobDetail`. Trivial, breaking-OK now, impossible post-tag.
+
+---
+
+## MAJOR — correctness / liveness (should fix before GA)
+
+- [ ] **M1. Fresh session sends `TYPE \x00` on first transfer.** `newSession` (`ftp.go:99`) never
+  initializes `currType`; `currentType()` returns `TransferType(0)` until a SetType. On
+  `Open→Login→Get`, `defer restoreType(0,…)` → `SetType(0)` → `"TYPE \x00"` (`transfer.go:50`).
+  z/OS rejects it; since the transfer succeeded, `restoreType` injects the error into the named
+  return → a successful Get/Put returns a spurious error. Masked by a lenient mock.
+  Fix: init `currType = TypeAscii` (RFC 959 default representation type) in `newSession`.
+
+- [ ] **M2. Unbounded control reads.** `sendLocked` (`cmd.go:48`) arms a deadline only when the
+  context has one; `SendCommand` passes `context.Background()`. So the `REST` reply
+  (`transfer.go:117`), the `RETR/STOR` 125/150 reply (`transfer.go:122`), and every internal
+  command block forever on a server that accepts then stalls. Only `checkLast` is bounded.
+  Fix: route REST + the data command through a bounded context; consider a default per-command deadline.
+
+- [ ] **M3. Data-connection TLS handshake unbounded.** `passive.go:170` `tls.Client(conn, …)` with no
+  `HandshakeContext`/deadline; handshake fires lazily on first Read/Write. `DialTimeout` covered
+  only the TCP dial → a stalled FTPS data negotiation hangs the transfer.
+  Fix: `tls.Conn.HandshakeContext` with a deadline (or `SetDeadline` around first use).
+
+- [ ] **M4. EOF-truncated multiline reply reported as success.** `codes.go:143` — on EOF after the
+  opening line, `check` breaks; if `openingCode == expected`, the guard at `codes.go:191` is false
+  → returns `(partialText, nil)`. A reply cut off after its opening line is consumed as complete
+  success, leaving a desynced session for the next call. (Distinct from ZH02/#41 = EOF *before* opening.)
+  Fix: track `sawTerminator`; on EOF without it return `io.ErrUnexpectedEOF` (→ session close).
+
+- [ ] **M5. `checkLast` returns `("",nil)` on a closed session** — `cmd.go:128`. `confirmData` then
+  reports an **unconfirmed transfer as success** when the session was closed concurrently. Public
+  `CheckLast` also yields silent empty-success.
+  Fix: return `net.ErrClosed` so completion is never claimed without a confirmed code.
+
+- [ ] **M6. JES abends not detected.** `jes.go` `classifyJesOutput` keys on `abaMessages`
+  (ABAxxx = DFSMShsm *Aggregate Backup Assist*, not abends). A real `S0C7`/`U0778` surfaces as
+  `$HASP395 … ENDED - ABEND=S0C7`, matching neither the tables nor the RC regex → misleading
+  "failed to retrieve job-id", no abend signal. Doc comments calling ABAxxx "abend messages" are wrong.
+  Fix: add an abend matcher + sentinel; correct the comments. (Confirm against a real-LPAR job — ZH12 no-fabricate rule.)
+
+- [ ] **M7. Passive-mode abort leaks a multi-reply control desync ("message mess").** *(added 2026-06-24)*
+  Aborting an in-progress passive transfer makes z/OS emit **more than one** control reply —
+  `426 Connection closed; transfer aborted.` then `226 … ABOR command successful.` — and the count
+  is **non-deterministic** (if the transfer finished a beat before the abort landed, only `226`).
+  Any abort path that closes **only the data connection** and keeps the control connection drains
+  one reply and leaves the rest buffered → the next command reads shifted garbage. Compounded by
+  z/OS **RST-on-abort** (APAR PQ54076) and the **async** `226`. Plain `ABOR\r\n` may sit queued
+  behind in-flight data — RFC 959 §4.1.3 requires Telnet **IP** (`0xFF 0xF4`) + **Synch**
+  (`0xFF 0xF2`, TCP urgent) so the server sees it out-of-band.
+  Current state: the data-stream-error path closes the whole session (`transfer.go:132`, correct);
+  there is **no** `Abort()`/keep-session path that drains correctly.
+  Fix — pick one, no middle ground:
+  - **A. Proper ABOR (keep session):** send Telnet IP+Synch+ABOR, then loop-read control replies
+    under a deadline, discarding `426`, draining until the final `2xx`. Only then is the stream reusable.
+  - **B. Abort-by-close (bulletproof):** route every abort through `s.Close()`. No drain, no reconcile.
+  Forbid the "close just the data conn and keep going" path — that is exactly what produces the mess.
+
+---
+
+## MINOR — polish (shippable; fast-follow)
+
+- [ ] **doc-coverage gate is half-blind** — `doc_coverage_test.go:23` scans only `os.ReadDir(".")`;
+  `hfs`/`eol` exported idents ungated (~20 undocumented). Walk subpackages.
+- [ ] **Dead code** — `utils.Prefix/Suffix/PrefixString/SuffixString/IsMigrated/IsNotMounted`
+  (`internal/utils/utils.go:20-46`) have zero non-test callers (`Prefix/Suffix` would panic on a
+  blank line if revived). Delete.
+- [ ] **`StandardizeQuote` is a no-op sanitizer** — `internal/utils/utils.go:118` discards the
+  `ReplaceAllString` result, quotes the unmodified name. Assign the result, or remove.
+- [ ] **SITE attr leak** — `SubmitJesGetByDSN` (`jes.go:106`) saves/restores FILETYPE but leaks
+  `RECFM/LRECL/BLKSIZE` into later commands. Save/restore or document.
+- [ ] **`(sz, msg string, err error)` triple** on the four `*IO` methods — every caller discards `msg`
+  with `_`. Non-idiomatic, locks into the signature. Consider `(int64, error)` now.
+- [ ] **Status shape** — `StatusOf()` → ~72 getters, each one XSTA round-trip, no batch `Snapshot()`.
+  Permanent surface; `STAT` is the only bulk escape hatch. Consider a typed snapshot now.
+- [ ] **`WithRecfmFB` etc. are bare consts, not funcs** while `WithLrecl()/WithBlkSize()` are funcs —
+  mis-signals callability; `SetDataSpecs` godoc references a nonexistent `Recfm(...)` ctor.
+- [ ] **Trailing space** — `parseCommand` emits `"NOOP \r\n"` (`cmd.go:101`).
+- [ ] **Login state hygiene** — sets `s.user` before USER/PASS succeed; failed login leaves
+  `GetUser()` returning the attempted name.
+- [ ] **Signal handler never released** — `ftp.go:111` `signal.Notify` with no `signal.Stop`; leaks a
+  goroutine per `Open(WithSignalHandler())`. CLI single-session → acceptable; document.
+- [ ] **cli `go install` broken from clean checkout** — `require v2.0.0` (untagged) + `replace =>../`.
+  Documented "development builds only"; binary-first distribution → not a true blocker. For GA: tag
+  the cli module + drop the replace, or soften the README.
+
+### Nits
+- `eol.Cr` deprecation not machine-readable (use `// Deprecated:` prefix).
+- `GetUser()` vs noun-naming (`RemoteAddr`, etc.) — consider `User()`.
+- `TransferType(0).Name()` returns "BINARY" — consider an "UNKNOWN"/default branch.
+- `StatusOf()`/`SetStatusOf()` noun pairing reads oddly.
+
+---
+
+## Verified SOLID (re-checked; hardening held)
+
+Concurrency (non-reentrant mutex, `sendLocked`/`*Locked` discipline, atomic `currType`/`isClosed`,
+idempotent Close, lock-atomic Rename) · FILETYPE save/restore on every error path · REST/ASCII
+`guardResume` at all four `*At` entries before any I/O · dataset positional parsing (bounds-guarded,
+no panic on short lines) · `recFmt` getters (Lrecl=m[2]/BlockSize=m[3]/Recfm=m[1], no transposition) ·
+data-stream-failure → session close (no desync) · `restoreType` error-preservation ·
+`ReturnError` Is/Unwrap/CodeError · password masking in `parseCommand` ·
+**multiline terminator detection** (`codes.go` opening-code anchoring — the ZH02 fix is correct).

--- a/eol/eol.go
+++ b/eol/eol.go
@@ -36,7 +36,9 @@ func (l lf) NewLine() string {
 
 type cr string
 
-// Cr is the legacy Mac/OS end-of-line sequence. (deprecated)
+// Cr is the legacy (pre-OSX) Mac end-of-line sequence, a lone carriage return.
+//
+// Deprecated: classic Mac line endings are obsolete; use [Lf] or [Crlf] instead.
 const Cr = cr("CR")
 
 func (c cr) String() string {

--- a/eol/eol_unix.go
+++ b/eol/eol_unix.go
@@ -4,4 +4,6 @@
 
 package eol
 
+// System is the host platform's native end-of-line sequence. On non-Windows
+// platforms it is [Lf].
 const System = Lf

--- a/eol/eol_windows.go
+++ b/eol/eol_windows.go
@@ -2,4 +2,6 @@
 
 package eol
 
+// System is the host platform's native end-of-line sequence. On Windows it is
+// [Crlf].
 const System = Crlf

--- a/ftp.go
+++ b/ftp.go
@@ -96,7 +96,7 @@ func dialControl(server string, cfg dialOptions) (net.Conn, error) {
 // newSession wraps an established control connection in an FTPSession. It is the
 // unexported construction seam shared by Open and by in-process tests.
 func newSession(conn net.Conn, cfg dialOptions) *FTPSession {
-	return &FTPSession{
+	s := &FTPSession{
 		conn:      conn,
 		rawConn:   conn,
 		reader:    bufio.NewReader(conn),
@@ -104,10 +104,19 @@ func newSession(conn net.Conn, cfg dialOptions) *FTPSession {
 		jobPrefix: regexp.MustCompile(`(JOB\d{5})`),
 		log:       log.New(cfg.logger, log.None),
 	}
+	// The server's representation type at connect is ASCII (RFC 959 §3.1.1.3).
+	// Seed currType so a transfer that restores the prior type before any explicit
+	// SetType (e.g. on a session used before Login) never emits "TYPE \x00".
+	s.currType.Store(uint32(TypeAscii))
+	return s
 }
 
-// installSignalHandler tears the session down on SIGINT/SIGTERM and exits.
-// Only installed when WithSignalHandler is set.
+// installSignalHandler tears the session down on SIGINT/SIGTERM and exits the
+// process. It is installed only when WithSignalHandler is set (opt-in, intended
+// for the CLI). The signal registration and its goroutine live for the process
+// lifetime — there is no signal.Stop — so it is meant for a single, long-lived
+// session: opening many sessions with WithSignalHandler leaks one goroutine each,
+// and because the first signal calls os.Exit, only one handler ever runs.
 func (s *FTPSession) installSignalHandler() {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
@@ -262,8 +271,6 @@ func (s *FTPSession) Login(user, pass string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.user = strings.ToUpper(user)
-
 	// The whole login handshake runs under s.mu, so every step uses the locked
 	// helpers (sendLocked / setTypeLocked / setStatusOfLocked) to avoid the
 	// re-entrant deadlock a sync.Mutex would otherwise cause.
@@ -276,6 +283,9 @@ func (s *FTPSession) Login(user, pass string) error {
 	if err != nil {
 		return err
 	}
+	// Record the user only after PASS succeeds, so a failed login leaves no stale
+	// username readable via User.
+	s.user = strings.ToUpper(user)
 	// set passive mode
 	_, err = s.sendLocked(context.Background(), CodeEnteringPassiveMode, "PASV")
 	if err != nil {
@@ -315,8 +325,8 @@ func (s *FTPSession) Login(user, pass string) error {
 	return nil
 }
 
-// GetUser returns the current username
-func (s *FTPSession) GetUser() string {
+// User returns the current username
+func (s *FTPSession) User() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.user

--- a/get.go
+++ b/get.go
@@ -33,7 +33,7 @@ func (s *FTPSession) Get(remote string, localFile string, mode TransferType) err
 	}()
 
 	s.log.Debug("starting transfer from: ", remote)
-	bytesTransferred, _, err := s.RetrieveIO(remote, file, mode)
+	bytesTransferred, err := s.RetrieveIO(remote, file, mode)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve file: %w", err)
 	}
@@ -85,7 +85,7 @@ func (s *FTPSession) GetAt(remote string, localFile string, mode TransferType, o
 	}()
 
 	s.log.Debugf("starting transfer from %s at offset %d", remote, offset)
-	bytesTransferred, _, err := s.RetrieveIOAt(remote, file, mode, offset)
+	bytesTransferred, err := s.RetrieveIOAt(remote, file, mode, offset)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve file: %w", err)
 	}
@@ -117,7 +117,7 @@ func (s *FTPSession) GetAndGzip(remote string, localFile string, mode TransferTy
 	}()
 
 	s.log.Debug("starting transfer from: ", remote)
-	bytesTransferred, _, err := s.RetrieveIO(remote, gzWriter, mode)
+	bytesTransferred, err := s.RetrieveIO(remote, gzWriter, mode)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve and compress file: %w", err)
 	}

--- a/hfs/attributes.go
+++ b/hfs/attributes.go
@@ -16,6 +16,8 @@ import (
 	"time"
 )
 
+// FieldString holds a single whitespace-trimmed string column from a z/OS
+// listing.
 type FieldString struct {
 	data string
 }
@@ -25,18 +27,23 @@ func (f *FieldString) parse(data string) error {
 	return nil
 }
 
-func (f *FieldString) String() string {
+// String returns the trimmed column text.
+func (f FieldString) String() string {
 	return f.data
 }
 
-func (f *FieldString) Value() string {
+// Value returns the trimmed column text.
+func (f FieldString) Value() string {
 	return f.data
 }
 
-func (f *FieldString) MarshalJSON() ([]byte, error) {
+// MarshalJSON encodes the field as a JSON string.
+func (f FieldString) MarshalJSON() ([]byte, error) {
 	return json.Marshal(f.String())
 }
 
+// UnmarshalJSON decodes a JSON string into the field, trimming surrounding
+// whitespace.
 func (f *FieldString) UnmarshalJSON(b []byte) error {
 	var s string
 	if err := json.Unmarshal(b, &s); err != nil {
@@ -94,7 +101,10 @@ func (f *FieldInt) parse(data string) error {
 	return nil
 }
 
-func (f *FieldInt) String() string {
+// String returns the base-10 representation of the value, the overflow marker
+// ("+++++") when the source column overflowed, or "" when the value is zero or
+// absent.
+func (f FieldInt) String() string {
 	if f.overflow {
 		return overflowMarker
 	}
@@ -107,17 +117,20 @@ func (f *FieldInt) String() string {
 // IsOverflow reports whether the source column held a z/OS display-overflow
 // indicator ("+++++") rather than a representable number. When true, Value() is
 // 0 and carries no meaning.
-func (f *FieldInt) IsOverflow() bool {
+func (f FieldInt) IsOverflow() bool {
 	return f.overflow
 }
 
 // Value returns the parsed integer. It is 0 for both an absent column and a
 // display overflow; use IsOverflow to tell the two apart.
-func (f *FieldInt) Value() uint32 {
+func (f FieldInt) Value() uint32 {
 	return f.data
 }
 
-func (f *FieldInt) MarshalJSON() ([]byte, error) {
+// MarshalJSON encodes the value as a JSON number, as the overflow marker string
+// ("+++++") when the column overflowed, or as null when the value is zero or
+// absent.
+func (f FieldInt) MarshalJSON() ([]byte, error) {
 	if f.overflow {
 		return json.Marshal(overflowMarker)
 	}
@@ -127,6 +140,9 @@ func (f *FieldInt) MarshalJSON() ([]byte, error) {
 	return json.Marshal(f.data)
 }
 
+// UnmarshalJSON decodes a JSON number into the value, accepts the overflow marker
+// string ("+++++") as a display overflow, and treats null as zero. Any other
+// string is rejected.
 func (f *FieldInt) UnmarshalJSON(b []byte) error {
 	f.data = 0
 	f.overflow = false
@@ -155,6 +171,7 @@ func (f *FieldInt) UnmarshalJSON(b []byte) error {
 
 /* ------------------------------------------------------------------------------------------------------------------ */
 
+// FieldFloat holds a single 32-bit floating-point column from a z/OS listing.
 type FieldFloat struct {
 	data float32
 }
@@ -173,24 +190,30 @@ func (f *FieldFloat) parse(data string) error {
 	return nil
 }
 
-func (f *FieldFloat) String() string {
+// String returns the value formatted as "%05.02f", or "" when it is zero or
+// absent.
+func (f FieldFloat) String() string {
 	if f.data == 0 {
 		return ""
 	}
 	return fmt.Sprintf("%05.02f", f.data)
 }
 
-func (f *FieldFloat) Value() float32 {
+// Value returns the parsed floating-point value.
+func (f FieldFloat) Value() float32 {
 	return f.data
 }
 
-func (f *FieldFloat) MarshalJSON() ([]byte, error) {
+// MarshalJSON encodes the value as a JSON number, or as null when it is zero or
+// absent.
+func (f FieldFloat) MarshalJSON() ([]byte, error) {
 	if f.data == 0 {
 		return []byte("null"), nil
 	}
 	return json.Marshal(f.Value())
 }
 
+// UnmarshalJSON decodes a JSON number into the value, treating null as zero.
 func (f *FieldFloat) UnmarshalJSON(b []byte) error {
 	var n float32
 	if string(b) == "null" {
@@ -206,6 +229,7 @@ func (f *FieldFloat) UnmarshalJSON(b []byte) error {
 
 /* ------------------------------------------------------------------------------------------------------------------ */
 
+// FieldDate holds a single date column (no time component) from a z/OS listing.
 type FieldDate struct {
 	data time.Time
 }
@@ -229,21 +253,27 @@ func (f *FieldDate) parse(data string) error {
 	return fmt.Errorf("failed to parse date field: %q", data)
 }
 
-func (f *FieldDate) String() string {
+// String returns the date formatted as "yyyy/mm/dd", or "" when it is unset.
+func (f FieldDate) String() string {
 	if f.data.IsZero() {
 		return ""
 	}
 	return f.data.Format("2006/01/02")
 }
 
-func (f *FieldDate) Value() time.Time {
+// Value returns the parsed date as a time.Time, which is the zero time when
+// unset.
+func (f FieldDate) Value() time.Time {
 	return f.data
 }
 
-func (f *FieldDate) MarshalJSON() ([]byte, error) {
+// MarshalJSON encodes the date as a JSON "yyyy/mm/dd" string (empty when unset).
+func (f FieldDate) MarshalJSON() ([]byte, error) {
 	return json.Marshal(f.String())
 }
 
+// UnmarshalJSON decodes a JSON date string into the field, accepting the
+// "yyyy/mm/dd" and "mm/dd/yy" layouts and the "**NONE**" sentinel.
 func (f *FieldDate) UnmarshalJSON(b []byte) error {
 	var s string
 	if err := json.Unmarshal(b, &s); err != nil {
@@ -254,6 +284,7 @@ func (f *FieldDate) UnmarshalJSON(b []byte) error {
 
 /* ------------------------------------------------------------------------------------------------------------------ */
 
+// FieldTime holds a single date-and-time column from a z/OS listing.
 type FieldTime struct {
 	data time.Time
 }
@@ -273,21 +304,29 @@ func (f *FieldTime) parse(data string) error {
 	return nil
 }
 
-func (f *FieldTime) String() string {
+// String returns the timestamp formatted as "yyyy/mm/dd HH:MM", or "" when it is
+// unset.
+func (f FieldTime) String() string {
 	if f.data.IsZero() {
 		return ""
 	}
 	return f.data.Format("2006/01/02 15:04")
 }
 
-func (f *FieldTime) Value() time.Time {
+// Value returns the parsed timestamp as a time.Time, which is the zero time when
+// unset.
+func (f FieldTime) Value() time.Time {
 	return f.data
 }
 
-func (f *FieldTime) MarshalJSON() ([]byte, error) {
+// MarshalJSON encodes the timestamp as a JSON "yyyy/mm/dd HH:MM" string (empty
+// when unset).
+func (f FieldTime) MarshalJSON() ([]byte, error) {
 	return json.Marshal(f.String())
 }
 
+// UnmarshalJSON decodes a JSON "yyyy/mm/dd HH:MM" timestamp string into the
+// field.
 func (f *FieldTime) UnmarshalJSON(b []byte) error {
 	var s string
 	if err := json.Unmarshal(b, &s); err != nil {

--- a/hfs/attributes.go
+++ b/hfs/attributes.go
@@ -16,6 +16,30 @@ import (
 	"time"
 )
 
+// Compile-time checks: the value types satisfy fmt.Stringer and json.Marshaler BY
+// VALUE (the hfs listing APIs return value slices, e.g. []InfoDataset), and the
+// pointer types satisfy json.Unmarshaler. A receiver change that broke these — so
+// that fmt printed the raw struct or json.Marshal emitted {} — would fail the build.
+var (
+	_ fmt.Stringer = FieldString{}
+	_ fmt.Stringer = FieldInt{}
+	_ fmt.Stringer = FieldFloat{}
+	_ fmt.Stringer = FieldDate{}
+	_ fmt.Stringer = FieldTime{}
+
+	_ json.Marshaler = FieldString{}
+	_ json.Marshaler = FieldInt{}
+	_ json.Marshaler = FieldFloat{}
+	_ json.Marshaler = FieldDate{}
+	_ json.Marshaler = FieldTime{}
+
+	_ json.Unmarshaler = (*FieldString)(nil)
+	_ json.Unmarshaler = (*FieldInt)(nil)
+	_ json.Unmarshaler = (*FieldFloat)(nil)
+	_ json.Unmarshaler = (*FieldDate)(nil)
+	_ json.Unmarshaler = (*FieldTime)(nil)
+)
+
 // FieldString holds a single whitespace-trimmed string column from a z/OS
 // listing.
 type FieldString struct {

--- a/hfs/attributes_test.go
+++ b/hfs/attributes_test.go
@@ -40,11 +40,10 @@ func TestFieldInt_OverflowDistinctFromRealMax(t *testing.T) {
 	if overflow.String() == real.String() {
 		t.Errorf("overflow String()=%q indistinguishable from real %q", overflow.String(), real.String())
 	}
-	if overflow.Value() == real.Value() && !real.IsOverflow() && overflow.IsOverflow() {
-		// Value() may legitimately be 0 for overflow; that is fine *because*
-		// IsOverflow() disambiguates. This guard only fails if NOTHING
-		// distinguishes them, which is the bug.
-	}
+	// Value() may legitimately be 0 for an overflow; that is fine *because*
+	// IsOverflow() (asserted above) disambiguates it from a real 0. The String()
+	// and JSON guards here and below prove they are distinguishable on every
+	// observable surface.
 	realJSON := mustMarshal(t, &real)
 	overflowJSON := mustMarshal(t, &overflow)
 	if realJSON == overflowJSON {

--- a/hfs/dataset.go
+++ b/hfs/dataset.go
@@ -42,6 +42,9 @@ type InfoDataset struct {
 	state string
 }
 
+// InfoDataset satisfies fmt.Stringer by value (ListDatasets returns []InfoDataset).
+var _ fmt.Stringer = InfoDataset{}
+
 // Name returns DName but without the quotes
 func (d *InfoDataset) Name() string {
 	return strings.Trim(d.Dsname.String(), "'")

--- a/hfs/dataset.go
+++ b/hfs/dataset.go
@@ -10,16 +10,28 @@ import (
 
 // InfoDataset is a struct that represents a z/OS dataset
 type InfoDataset struct {
-	Dsname   FieldString `json:"Dsname"`
-	Volume   FieldString `json:"Volume"`
-	Unit     FieldString `json:"Unit"`
-	Referred FieldDate   `json:"Referred"`
-	Ext      FieldInt    `json:"Ext"`
-	Used     FieldInt    `json:"Used"`
-	Recfm    FieldString `json:"Recfm"`
-	Lrecl    FieldInt    `json:"Lrecl"`
-	BlkSz    FieldInt    `json:"BlkSz"`
-	Dsorg    FieldString `json:"Dsorg"`
+	// Dsname is the fully qualified dataset name, including the surrounding
+	// single quotes as reported by z/OS.
+	Dsname FieldString `json:"Dsname"`
+	// Volume is the volume serial (VOLSER) on which the dataset resides.
+	Volume FieldString `json:"Volume"`
+	// Unit is the device unit/type the dataset is allocated on (e.g. "3390").
+	Unit FieldString `json:"Unit"`
+	// Referred is the date the dataset was last referenced.
+	Referred FieldDate `json:"Referred"`
+	// Ext is the number of extents the dataset currently occupies.
+	Ext FieldInt `json:"Ext"`
+	// Used is the amount of space used, in the units reported by the listing
+	// (typically tracks).
+	Used FieldInt `json:"Used"`
+	// Recfm is the record format (e.g. "FB", "VB", "U").
+	Recfm FieldString `json:"Recfm"`
+	// Lrecl is the logical record length, in bytes.
+	Lrecl FieldInt `json:"Lrecl"`
+	// BlkSz is the block size, in bytes.
+	BlkSz FieldInt `json:"BlkSz"`
+	// Dsorg is the dataset organization (e.g. "PO", "PS", "VSAM").
+	Dsorg FieldString `json:"Dsorg"`
 	// Tracks is the allocated-track count reported only by the Co:Z SFTP listing
 	// format (which has a distinct Tracks column); it is zero for the IBM z/OS FTP
 	// formats, which do not carry it.
@@ -110,7 +122,7 @@ func (d *InfoDataset) ToStringSlice() []string {
 }
 
 // String return a row of text representing the dataset
-func (d *InfoDataset) String() string {
+func (d InfoDataset) String() string {
 	str := strings.Builder{}
 	str.WriteString(fmt.Sprintf("Name: %s, ", d.Dsname.String()))
 	str.WriteString(fmt.Sprintf("Volume: %s, ", d.Volume.String()))

--- a/hfs/jobdetail_export_test.go
+++ b/hfs/jobdetail_export_test.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package hfs_test
+
+import (
+	"testing"
+
+	"gopkg.in/ro-ag/zftp.v2/hfs"
+)
+
+// InfoJobDetail.Detail must return a slice of an EXPORTED type so external
+// callers can name it, declare variables of it, and read its fields. Returning
+// []jobDetail (unexported) makes per-step JES detail unusable outside the package.
+func TestDetailReturnsExportedType(t *testing.T) {
+	var jd hfs.InfoJobDetail
+	var _ []hfs.JobDetail = jd.Detail()
+}

--- a/hfs/partitioned.go
+++ b/hfs/partitioned.go
@@ -23,6 +23,9 @@ type InfoPdsMember struct {
 	Id      FieldString `json:"Id"`      // Id The user ID of the person who created or last updated this version
 }
 
+// InfoPdsMember satisfies fmt.Stringer by value (ListPds returns []InfoPdsMember).
+var _ fmt.Stringer = InfoPdsMember{}
+
 // String returns a row of text representing the Partitioned Dataset member
 func (m InfoPdsMember) String() string {
 	str := strings.Builder{}

--- a/hfs/partitioned.go
+++ b/hfs/partitioned.go
@@ -24,7 +24,7 @@ type InfoPdsMember struct {
 }
 
 // String returns a row of text representing the Partitioned Dataset member
-func (m *InfoPdsMember) String() string {
+func (m InfoPdsMember) String() string {
 	str := strings.Builder{}
 	str.WriteString(fmt.Sprintf("Name: %s, ", m.Name.String()))
 	str.WriteString(fmt.Sprintf("VV.MM: %s, ", m.VvMm.String()))
@@ -37,6 +37,8 @@ func (m *InfoPdsMember) String() string {
 	return str.String()
 }
 
+// ToStringSlice returns the member's columns as a slice of strings, in the same
+// order as Headers (Name, VV.MM, Created, Changed, Size, Init, Mod, Id).
 func (m *InfoPdsMember) ToStringSlice() []string {
 	return []string{
 		m.Name.String(),

--- a/hfs/spool.go
+++ b/hfs/spool.go
@@ -42,16 +42,25 @@ var (
 // records Class is empty and SpoolFiles is N; for JesInterfaceLevel=2 records,
 // which carry a real class, SpoolFiles is 0.
 type InfoJob struct {
-	Name       FieldString `json:"Name"`
-	JobId      FieldString `json:"JobId"`
-	Owner      FieldString `json:"Owner"`
-	Status     FieldString `json:"Status"`
-	Class      FieldString `json:"Class"`
-	SpoolFiles int         `json:"SpoolFiles,omitempty"`
+	// Name is the job name (the JOBNAME column).
+	Name FieldString `json:"Name"`
+	// JobId is the JES job identifier (e.g. "JOB12345").
+	JobId FieldString `json:"JobId"`
+	// Owner is the user ID that owns the job. It is empty for
+	// JesInterfaceLevel=1 listings, which omit the owner column.
+	Owner FieldString `json:"Owner"`
+	// Status is the job status (e.g. "ACTIVE", "OUTPUT").
+	Status FieldString `json:"Status"`
+	// Class is the job class for JesInterfaceLevel=2 listings; it is empty for
+	// JesInterfaceLevel=1 listings, which report a spool-file count instead.
+	Class FieldString `json:"Class"`
+	// SpoolFiles is the spool-file count from a JesInterfaceLevel=1 listing; it
+	// is 0 for JesInterfaceLevel=2 listings.
+	SpoolFiles int `json:"SpoolFiles,omitempty"`
 }
 
 // String returns a row of text representing the job.
-func (j *InfoJob) String() string {
+func (j InfoJob) String() string {
 	str := strings.Builder{}
 	str.WriteString(fmt.Sprintf("Name: %s, ", j.Name.String()))
 	str.WriteString(fmt.Sprintf("JobId: %s, ", j.JobId.String()))
@@ -159,7 +168,7 @@ func parseLineJob(line string, level int) (j InfoJob, err error) {
 // InfoJobDetail contains the job record and the job details.
 type InfoJobDetail struct {
 	job    InfoJob
-	detail []jobDetail
+	detail []JobDetail
 }
 
 // Job returns the job record.
@@ -168,7 +177,7 @@ func (j InfoJobDetail) Job() InfoJob {
 }
 
 // Detail returns the job details.
-func (j InfoJobDetail) Detail() []jobDetail {
+func (j InfoJobDetail) Detail() []JobDetail {
 	return j.detail
 }
 
@@ -210,18 +219,27 @@ func (j InfoJobDetail) ReturnCode() (rc int, err error) {
 	return rc, err
 }
 
-// InfoJobDetail returns the job details, contains the STEPS
-type jobDetail struct {
-	Id        FieldInt    `json:"Id"`
-	StepName  FieldString `json:"StepName"`
-	ProcSpec  FieldString `json:"ProcSpec"`
-	C         FieldString `json:"C"`
-	DDName    FieldString `json:"DDName"`
-	ByteCount FieldInt    `json:"ByteCount"`
+// JobDetail represents one step's spool detail within a job (the columns of a
+// JesInterfaceLevel=2 job listing): step id, step name, procedure step, class,
+// DD name, and byte count.
+type JobDetail struct {
+	// Id is the spool dataset's sequence number within the job (the ID column).
+	Id FieldInt `json:"Id"`
+	// StepName is the job step name (the STEPNAME column).
+	StepName FieldString `json:"StepName"`
+	// ProcSpec is the procedure step name (the PROCSTEP column).
+	ProcSpec FieldString `json:"ProcSpec"`
+	// C is the SYSOUT class of the spool dataset (the single-character C column).
+	C FieldString `json:"C"`
+	// DDName is the DD name of the spool dataset (the DDNAME column).
+	DDName FieldString `json:"DDName"`
+	// ByteCount is the size of the spool dataset, in bytes (the BYTE-COUNT
+	// column).
+	ByteCount FieldInt `json:"ByteCount"`
 }
 
 // String returns a row of text representing the job detail.
-func (j jobDetail) String() string {
+func (j JobDetail) String() string {
 	str := strings.Builder{}
 	str.WriteString(fmt.Sprintf("Id: %d, ", j.Id.Value()))
 	str.WriteString(fmt.Sprintf("StepName: %s, ", j.StepName.String()))
@@ -294,7 +312,7 @@ func ParseInfoJobDetail(records []string) (*InfoJobDetail, error) {
 	}
 	i++
 
-	dt := make([]jobDetail, 0)
+	dt := make([]JobDetail, 0)
 	for ; i < len(records); i++ {
 		if strings.TrimSpace(records[i]) == "" {
 			continue
@@ -320,8 +338,8 @@ func ParseInfoJobDetail(records []string) (*InfoJobDetail, error) {
 	return jd, nil
 }
 
-func parseJobDetailLine(line string) (jobDetail, error) {
-	s := jobDetail{}
+func parseJobDetailLine(line string) (JobDetail, error) {
+	s := JobDetail{}
 	fields := whitespaceRegex.Split(strings.TrimSpace(line), 6)
 	if len(fields) != 6 {
 		return s, fmt.Errorf("invalid record: '%s'", line)

--- a/hfs/spool.go
+++ b/hfs/spool.go
@@ -59,6 +59,13 @@ type InfoJob struct {
 	SpoolFiles int `json:"SpoolFiles,omitempty"`
 }
 
+// InfoJob and JobDetail satisfy fmt.Stringer by value (ListSpool returns
+// []InfoJob; InfoJobDetail.Detail returns []JobDetail).
+var (
+	_ fmt.Stringer = InfoJob{}
+	_ fmt.Stringer = JobDetail{}
+)
+
 // String returns a row of text representing the job.
 func (j InfoJob) String() string {
 	str := strings.Builder{}

--- a/hfs/value_receiver_test.go
+++ b/hfs/value_receiver_test.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package hfs
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// The public listing APIs (ListDatasets/ListPds/ListSpool, GetJobStatus) hand
+// back value types ([]InfoDataset, []InfoJob, ...). For fmt and encoding/json to
+// work on those values, the value types — and the Field* types they embed — must
+// satisfy fmt.Stringer and json.Marshaler BY VALUE. A pointer-only receiver makes
+// fmt print the raw struct and, for json on a non-addressable value, emit {}.
+var (
+	_ fmt.Stringer = FieldString{}
+	_ fmt.Stringer = FieldInt{}
+	_ fmt.Stringer = FieldFloat{}
+	_ fmt.Stringer = FieldDate{}
+	_ fmt.Stringer = FieldTime{}
+	_ fmt.Stringer = InfoDataset{}
+	_ fmt.Stringer = InfoPdsMember{}
+	_ fmt.Stringer = InfoJob{}
+
+	_ json.Marshaler = FieldString{}
+	_ json.Marshaler = FieldInt{}
+	_ json.Marshaler = FieldFloat{}
+	_ json.Marshaler = FieldDate{}
+	_ json.Marshaler = FieldTime{}
+)
+
+func TestInfoJobValueMarshalsFields(t *testing.T) {
+	j := InfoJob{
+		Name:   FieldString{data: "MYJOB"},
+		JobId:  FieldString{data: "JOB01234"},
+		Owner:  FieldString{data: "IBMUSER"},
+		Status: FieldString{data: "OUTPUT"},
+		Class:  FieldString{data: "A"},
+	}
+	b, err := json.Marshal(j) // value, exactly as the CLI's emit() passes it
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), `"Name":{}`) {
+		t.Fatalf("InfoJob value marshalled Name as {} (pointer-receiver MarshalJSON): %s", b)
+	}
+	if !strings.Contains(string(b), "MYJOB") {
+		t.Fatalf("expected MYJOB in JSON, got %s", b)
+	}
+}
+
+func TestInfoJobValueSatisfiesStringer(t *testing.T) {
+	j := InfoJob{Name: FieldString{data: "MYJOB"}}
+	if got := fmt.Sprintf("%v", j); !strings.Contains(got, "MYJOB") {
+		t.Fatalf("fmt of InfoJob value did not call String(): %q", got)
+	}
+}

--- a/hfs/value_receiver_test.go
+++ b/hfs/value_receiver_test.go
@@ -10,26 +10,11 @@ import (
 )
 
 // The public listing APIs (ListDatasets/ListPds/ListSpool, GetJobStatus) hand
-// back value types ([]InfoDataset, []InfoJob, ...). For fmt and encoding/json to
-// work on those values, the value types — and the Field* types they embed — must
-// satisfy fmt.Stringer and json.Marshaler BY VALUE. A pointer-only receiver makes
-// fmt print the raw struct and, for json on a non-addressable value, emit {}.
-var (
-	_ fmt.Stringer = FieldString{}
-	_ fmt.Stringer = FieldInt{}
-	_ fmt.Stringer = FieldFloat{}
-	_ fmt.Stringer = FieldDate{}
-	_ fmt.Stringer = FieldTime{}
-	_ fmt.Stringer = InfoDataset{}
-	_ fmt.Stringer = InfoPdsMember{}
-	_ fmt.Stringer = InfoJob{}
-
-	_ json.Marshaler = FieldString{}
-	_ json.Marshaler = FieldInt{}
-	_ json.Marshaler = FieldFloat{}
-	_ json.Marshaler = FieldDate{}
-	_ json.Marshaler = FieldTime{}
-)
+// back value types ([]InfoDataset, []InfoJob, ...), so the value types must
+// satisfy fmt.Stringer and json.Marshaler BY VALUE. The compile-time guarantees
+// live in the source files (attributes.go/dataset.go/partitioned.go/spool.go);
+// these tests exercise the runtime behavior — that a value actually marshals its
+// fields rather than emitting {}, and prints via String().
 
 func TestInfoJobValueMarshalsFields(t *testing.T) {
 	j := InfoJob{

--- a/internal/transfer/operations.go
+++ b/internal/transfer/operations.go
@@ -15,6 +15,13 @@ type DataTransfer interface {
 	Command() string
 }
 
+// Compile-time checks that each transfer implementation satisfies DataTransfer.
+var (
+	_ DataTransfer = (*Store)(nil)
+	_ DataTransfer = (*Retrieve)(nil)
+	_ DataTransfer = (*StoreAscii)(nil)
+)
+
 type Store struct {
 	src io.Reader
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -3,7 +3,6 @@
 package utils
 
 import (
-	"bytes"
 	"encoding/binary"
 	"fmt"
 	"gopkg.in/ro-ag/zftp.v2/internal/log"
@@ -16,34 +15,6 @@ import (
 )
 
 var RegexSearchPattern = regexp.MustCompile(`[*?]|^\s*$`)
-
-func IsMigrated(line []byte) bool {
-	p := Prefix(line)
-	return bytes.HasPrefix(bytes.ToLower(p), []byte("migrated"))
-}
-
-func IsNotMounted(line []byte) bool {
-	p := Prefix(line)
-	return bytes.HasPrefix(bytes.ToLower(p), []byte("not mounted"))
-}
-
-func Prefix(line []byte) []byte {
-	f := bytes.Fields(line)
-	return f[0]
-}
-
-func PrefixString(line []byte) string {
-	return string(Prefix(line))
-}
-
-func Suffix(line []byte) []byte {
-	f := bytes.Fields(line)
-	return f[len(f)-1]
-}
-
-func SuffixString(line []byte) string {
-	return string(Suffix(line))
-}
 
 func Caller() string {
 	pc, _, _, _ := runtime.Caller(2)
@@ -113,11 +84,6 @@ func VerifyGzSize(lg *log.Logger, file *os.File, size int64) error {
 }
 
 var trims = regexp.MustCompile(`(^\s+|\s+$|^'|'$)|[\n\r]+`)
-
-func StandardizeQuote(name string) string {
-	trims.ReplaceAllString(name, "")
-	return fmt.Sprintf("'%s'", name)
-}
 
 func RemoveNewLine(name string) string {
 	return trims.ReplaceAllString(name, "")

--- a/jes.go
+++ b/jes.go
@@ -43,7 +43,7 @@ func (s *FTPSession) SubmitIO(jr io.Reader, options ...JesSpec) (*JesJob, error)
 	}
 	defer curr.Restore()
 
-	_, msg, err := s.StoreIO(job.DSN, jr, TypeAscii)
+	_, msg, err := s.storeIO(job.DSN, jr, TypeAscii)
 	if err != nil {
 		return nil, fmt.Errorf("failed to write JCL to FTP server: %w", err)
 	}
@@ -96,6 +96,11 @@ var (
 // it generates a unique job name and sets the site parameters to RECFM=FB LRECL=80 BLKSIZE=27920
 // it returns the whole Spool output as a string
 // this function waits for the job to complete
+//
+// NOTE: the RECFM/LRECL/BLKSIZE SITE attributes set here for the JCL upload are
+// NOT restored afterwards (only FILETYPE and the JES job-name filter are), so they
+// persist on the session for subsequent commands. Re-set them, or use a separate
+// session, if a later transfer needs different allocation attributes.
 func (s *FTPSession) SubmitJesGetByDSN(jcl string) (*JobResult, error) {
 	currSeq, err := utils.SetValueAndGetCurrent(s.log, "SEQ", s.SetStatusOf().FileType, s.StatusOf().FileType)
 	if err != nil {
@@ -112,7 +117,7 @@ func (s *FTPSession) SubmitJesGetByDSN(jcl string) (*JobResult, error) {
 
 	job.DSN = generateJobFileName()
 
-	_, _, err = s.StoreIO(job.DSN, strings.NewReader(jcl), TypeAscii)
+	_, err = s.StoreIO(job.DSN, strings.NewReader(jcl), TypeAscii)
 	if err != nil {
 		return nil, fmt.Errorf("failed to write JCL to FTP server: %w", err)
 	}
@@ -131,7 +136,7 @@ func (s *FTPSession) SubmitJesGetByDSN(jcl string) (*JobResult, error) {
 
 	jobOutput := &strings.Builder{}
 
-	_, msg, err := s.RetrieveIO(job.DSN, jobOutput, TypeAscii)
+	_, msg, err := s.retrieveIO(job.DSN, jobOutput, TypeAscii)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve job output: %w", err)
 	}
@@ -180,12 +185,18 @@ func (s *FTPSession) SubmitJesGetByDSN(jcl string) (*JobResult, error) {
 	return job, nil
 }
 
-// classifyJesOutput scans JES job output for ABEND (ABAxxx) and allocation/JCL
-// (IEFxxx) message identifiers, returning the matched, trimmed lines together with
-// the matching sentinel — ErrAba, ErrIEF, or ErrIEFAndABA when both kinds are
-// present. It returns (nil, nil) when no such message is found. The sentinel is
-// returned (not wrapped) so callers can match it with errors.Is once it is
-// wrapped with %w at the call site.
+// classifyJesOutput scans JES job output for DFSMShsm Aggregate Backup (ABAxxx)
+// and allocation/JCL (IEFxxx) message identifiers, returning the matched, trimmed
+// lines together with the matching sentinel — ErrAba, ErrIEF, or ErrIEFAndABA when
+// both kinds are present. It returns (nil, nil) when no such message is found. The
+// sentinel is returned (not wrapped) so callers can match it with errors.Is once
+// it is wrapped with %w at the call site.
+//
+// NOTE: ABAxxx are ABARS messages, not task abends (see ErrAba). A dedicated
+// matcher for a bare "$HASP395 jobname ENDED - ABEND=Scde" spool line is not yet
+// implemented here, pending a verified real-LPAR capture; today such abends are
+// detected only when they also emit an IEFxxx message or via the GetJobStatus
+// return-code path.
 func classifyJesOutput(output string) (details []string, errType error) {
 	lines := strings.Split(output, "\n")
 	/* analyze if job has abend errors */

--- a/jes_constants.go
+++ b/jes_constants.go
@@ -11,10 +11,17 @@ var (
 	// ErrIEF indicates the job output contained one or more IEFxxx allocation or
 	// JCL messages (see iefMessages).
 	ErrIEF = errors.New("IEF error")
-	// ErrAba indicates the job output contained one or more ABAxxx abend messages
-	// (see abaMessages).
+	// ErrAba indicates the job output contained one or more ABAxxx messages.
+	// Despite the historical "ABA error" text, ABAxxx identifiers are DFSMShsm
+	// Aggregate Backup And Recovery Support (ABARS) messages (see abaMessages,
+	// e.g. ABA001I "AGGREGATE BACKUP ASSIST ... STARTING") — NOT task abends. The
+	// name reflects the ABAxxx message prefix it matches, not an abend condition.
+	// (Job abends surface either as IEFxxx messages — e.g. IEF450I "ABEND Scde",
+	// IEF402I "SYSTEM ABEND Scde" — which are reported via ErrIEF, or in the
+	// $HASP395 completion line handled by the GetJobStatus return-code path.)
 	ErrAba = errors.New("ABA error")
-	// ErrIEFAndABA indicates the job output contained both IEF and ABA messages.
+	// ErrIEFAndABA indicates the job output contained both IEFxxx and ABAxxx
+	// messages.
 	ErrIEFAndABA = errors.New("IEF/ABA error")
 )
 

--- a/jes_test.go
+++ b/jes_test.go
@@ -87,13 +87,12 @@ HELLO, WORLD!
 		s.SetStatusOf().FileType("JES")
 		s.SetStatusOf().JesJobName("*")
 		jobOutput := &strings.Builder{}
-		n, str, err := s.RetrieveIO(job.ID, jobOutput, zftp.TypeAscii)
+		n, err := s.RetrieveIO(job.ID, jobOutput, zftp.TypeAscii)
 
 		if err != nil {
 			t.Fatal(err)
 		}
 		t.Logf("Retrieved %d bytes", n)
-		t.Logf("Output: %s", str)
 
 		t.Logf("Job output: %s", jobOutput.String())
 	})

--- a/lists_mock_test.go
+++ b/lists_mock_test.go
@@ -73,7 +73,7 @@ func TestListSpool(t *testing.T) {
 
 func TestSetDataSpecs_SiteCommand(t *testing.T) {
 	s, srv := dialMock(t)
-	if err := s.SetDataSpecs(zftp.WithRecfmFB, zftp.WithLrecl(80), zftp.WithBlkSize(27920)); err != nil {
+	if err := s.SetDataSpecs(zftp.RecfmFB, zftp.WithLrecl(80), zftp.WithBlkSize(27920)); err != nil {
 		t.Fatalf("SetDataSpecs: %v", err)
 	}
 	if !hasCmd(srv.Commands(), "SITE RECFM=FB LRECL=80 BLKSIZE=27920") {

--- a/options.go
+++ b/options.go
@@ -71,12 +71,13 @@ func WithKeepAlive(d time.Duration) Option {
 	return func(o *dialOptions) { o.KeepAlivePeriod = d }
 }
 
-// WithReplyTimeout bounds how long the client waits for the terminal reply (the
-// 226/250 that follows a data transfer). z/OS sends that reply asynchronously to
-// the data-connection close, and it can be lost — for example a NAT dropping an
-// idle control link during a long transfer — so bounding the read keeps a lost
-// reply from hanging the caller. Defaults to 120s; a non-positive duration
-// restores the default.
+// WithReplyTimeout bounds how long the client waits for a control-connection
+// reply. It applies both to the terminal reply that follows a data transfer (the
+// 226/250, which z/OS sends asynchronously to the data-connection close and which
+// can be lost — e.g. a NAT dropping an idle control link during a long transfer)
+// and to every command issued through SendCommand, so a server that accepts a
+// command but never replies cannot hang the caller. Defaults to 120s; a
+// non-positive duration restores the default.
 func WithReplyTimeout(d time.Duration) Option {
 	return func(o *dialOptions) { o.ReplyTimeout = d }
 }

--- a/passive.go
+++ b/passive.go
@@ -167,7 +167,19 @@ func (s *FTPSession) newChildConnection(port int) (*childConnection, error) {
 	}
 
 	if s.tlsConfig != nil {
-		conn = tls.Client(conn, s.tlsConfig)
+		// Bound the handshake: net.Dialer.Timeout covered only the TCP dial, so a
+		// peer that connects but stalls the TLS negotiation would otherwise hang the
+		// transfer on the first Read/Write. Fall back to the reply timeout when no
+		// dial timeout is configured so the bound is always finite.
+		hsTimeout := s.dialCfg.DialTimeout
+		if hsTimeout <= 0 {
+			hsTimeout = s.dialCfg.replyTimeout()
+		}
+		tconn, herr := tlsHandshakeBounded(conn, s.tlsConfig, hsTimeout)
+		if herr != nil {
+			return nil, fmt.Errorf("data-connection TLS handshake: %w", herr)
+		}
+		conn = tconn
 		s.log.Debugf("upgraded connection to TLS")
 	}
 
@@ -177,6 +189,28 @@ func (s *FTPSession) newChildConnection(port int) (*childConnection, error) {
 
 	s.log.Debugf("created child connection: %s", child.RemoteAddr().String())
 	return child, nil
+}
+
+// tlsHandshakeBounded wraps conn in a TLS client and drives the handshake under a
+// deadline, so a peer that completes the TCP dial but stalls the TLS negotiation
+// cannot hang the caller. The deadline is cleared on success; the data transfer
+// manages its own deadlines afterwards. On any failure the TLS connection (and the
+// underlying conn it owns) is closed before returning.
+func tlsHandshakeBounded(conn net.Conn, cfg *tls.Config, timeout time.Duration) (*tls.Conn, error) {
+	tconn := tls.Client(conn, cfg)
+	if err := tconn.SetDeadline(time.Now().Add(timeout)); err != nil {
+		_ = tconn.Close()
+		return nil, err
+	}
+	if err := tconn.Handshake(); err != nil {
+		_ = tconn.Close()
+		return nil, err
+	}
+	if err := tconn.SetDeadline(time.Time{}); err != nil {
+		_ = tconn.Close()
+		return nil, err
+	}
+	return tconn, nil
 }
 
 // newScanner returns a new scanner for the connection

--- a/passive.go
+++ b/passive.go
@@ -87,6 +87,10 @@ type childConnection struct {
 	lg       *log.Logger
 }
 
+// childConnection embeds net.Conn (overriding Close), so it satisfies net.Conn —
+// the type the transfer helpers expect for a data connection.
+var _ net.Conn = (*childConnection)(nil)
+
 // Close tears down the data connection. It is idempotent and safe to call
 // concurrently with an in-flight Read/Write/scan, which it interrupts so the
 // reader observes the closure promptly.

--- a/passive_tls_test.go
+++ b/passive_tls_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package zftp
+
+import (
+	"crypto/tls"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+// M3: the data-connection TLS handshake must be bounded. A peer that completes
+// the TCP dial but never speaks TLS (stalled ServerHello) must make the handshake
+// fail on a deadline rather than hang the transfer forever.
+func TestTLSHandshakeBounded_StalledServerTimesOut(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		io.Copy(io.Discard, c) // consume ClientHello, never reply → stalls handshake
+	}()
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		_, e := tlsHandshakeBounded(conn, &tls.Config{InsecureSkipVerify: true}, 200*time.Millisecond)
+		done <- e
+	}()
+	select {
+	case e := <-done:
+		if e == nil {
+			t.Fatal("expected a TLS handshake timeout error, got nil")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("TLS handshake hung: no deadline on the data-connection handshake")
+	}
+}

--- a/put.go
+++ b/put.go
@@ -56,7 +56,7 @@ func (s *FTPSession) Put(srcLocal string, destRemote string, mode TransferType, 
 
 	s.log.Debugf("starting transfer to: %s", destRemote)
 
-	bytesTransferred, _, err := s.StoreIO(destRemote, file, mode)
+	bytesTransferred, err := s.StoreIO(destRemote, file, mode)
 	if err != nil {
 		return fmt.Errorf("failed to store file: %w", err)
 	}
@@ -116,7 +116,7 @@ func (s *FTPSession) PutAt(srcLocal string, destRemote string, mode TransferType
 
 	s.log.Debugf("starting transfer to: %s at offset %d", destRemote, offset)
 
-	bytesTransferred, _, err := s.StoreIOAt(destRemote, file, mode, offset)
+	bytesTransferred, err := s.StoreIOAt(destRemote, file, mode, offset)
 	if err != nil {
 		return fmt.Errorf("failed to store file: %w", err)
 	}
@@ -131,47 +131,47 @@ type DataSpec interface {
 	Apply() (string, error)
 }
 
-// Recfm is a z/OS record format (RECFM) usable as a DataSpec via the WithRecfm…
-// constants; its Apply renders the SITE RECFM= subcommand.
+// Recfm is a z/OS record format (RECFM) usable as a DataSpec via the Recfm…
+// constants (e.g. RecfmFB); its Apply renders the SITE RECFM= subcommand.
 type Recfm string
 
 const (
-	WithRecfmF   Recfm = "F"   // Fixed record length
-	WithRecfmFB  Recfm = "FB"  // Fixed length records, Blocked
-	WithRecfmFBA Recfm = "FBA" // Fixed length records, Blocked, ASA control characters
-	WithRecfmFBM Recfm = "FBM" // Fixed length records, Blocked, Machine control characters
-	WithRecfmV   Recfm = "V"   // Variable record length
-	WithRecfmVB  Recfm = "VB"  // Variable length records, Blocked
-	WithRecfmVBA Recfm = "VBA" // Variable length records, Blocked, ASA control characters
-	WithRecfmVBM Recfm = "VBM" // Variable length records, Blocked, Machine control characters
-	WithRecfmU   Recfm = "U"   // Undefined record format
-	WithRecfmVS  Recfm = "VS"  // Variable record length, Spanned
-	WithRecfmVBS Recfm = "VBS" // Variable length records, Blocked, Spanned
+	RecfmF   Recfm = "F"   // Fixed record length
+	RecfmFB  Recfm = "FB"  // Fixed length records, Blocked
+	RecfmFBA Recfm = "FBA" // Fixed length records, Blocked, ASA control characters
+	RecfmFBM Recfm = "FBM" // Fixed length records, Blocked, Machine control characters
+	RecfmV   Recfm = "V"   // Variable record length
+	RecfmVB  Recfm = "VB"  // Variable length records, Blocked
+	RecfmVBA Recfm = "VBA" // Variable length records, Blocked, ASA control characters
+	RecfmVBM Recfm = "VBM" // Variable length records, Blocked, Machine control characters
+	RecfmU   Recfm = "U"   // Undefined record format
+	RecfmVS  Recfm = "VS"  // Variable record length, Spanned
+	RecfmVBS Recfm = "VBS" // Variable length records, Blocked, Spanned
 )
 
 func isValidRECFM(recfm Recfm) (string, bool) {
 	switch recfm {
-	case WithRecfmF:
+	case RecfmF:
 		return "Fixed record length", true
-	case WithRecfmFB:
+	case RecfmFB:
 		return "Fixed length records, Blocked", true
-	case WithRecfmFBA:
+	case RecfmFBA:
 		return "Fixed length records, Blocked, ASA control characters", true
-	case WithRecfmFBM:
+	case RecfmFBM:
 		return "Fixed length records, Blocked, Machine control characters", true
-	case WithRecfmV:
+	case RecfmV:
 		return "Variable record length", true
-	case WithRecfmVB:
+	case RecfmVB:
 		return "Variable length records, Blocked", true
-	case WithRecfmVBA:
+	case RecfmVBA:
 		return "Variable length records, Blocked, ASA control characters", true
-	case WithRecfmVBM:
+	case RecfmVBM:
 		return "Variable length records, Blocked, Machine control characters", true
-	case WithRecfmU:
+	case RecfmU:
 		return "Undefined record format", true
-	case WithRecfmVS:
+	case RecfmVS:
 		return "Variable record length, Spanned", true
-	case WithRecfmVBS:
+	case RecfmVBS:
 		return "Variable length records, Blocked, Spanned", true
 	default:
 		return "", false
@@ -221,7 +221,7 @@ func WithBlkSize(size uint16) DataSpec {
 // Valid attributes are:
 //   - WithLrecl(length uint16) - record length
 //   - WithBlkSize(size uint16) - block size
-//   - Recfm(recfm Recfm)   - record format
+//   - a Recfm constant (e.g. RecfmFB) - record format
 //
 // this function sends a SITE command to the server to set the attributes.
 func (s *FTPSession) SetDataSpecs(attributes ...DataSpec) error {

--- a/put.go
+++ b/put.go
@@ -206,6 +206,13 @@ func (r lrecl) Apply() (string, error) {
 	return fmt.Sprintf("LRECL=%d", r), nil
 }
 
+// Compile-time checks that the DataSpec implementations satisfy the interface.
+var (
+	_ DataSpec = Recfm("")
+	_ DataSpec = blksz(0)
+	_ DataSpec = lrecl(0)
+)
+
 // WithLrecl specs for dataset logical record length.
 func WithLrecl(length uint16) DataSpec {
 	return lrecl(length)

--- a/put_test.go
+++ b/put_test.go
@@ -22,7 +22,7 @@ func TestFTPSession_Put(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = s.SetDataSpecs(zftp.WithBlkSize(2403), zftp.WithLrecl(120), zftp.WithRecfmFB)
+	err = s.SetDataSpecs(zftp.WithBlkSize(2403), zftp.WithLrecl(120), zftp.RecfmFB)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -38,7 +38,7 @@ func TestFTPSession_Put(t *testing.T) {
 		zftp.TypeAscii,
 		zftp.WithBlkSize(2400),
 		zftp.WithLrecl(120),
-		zftp.WithRecfmFB,
+		zftp.RecfmFB,
 	)
 
 	if err != nil {

--- a/transfer.go
+++ b/transfer.go
@@ -50,12 +50,17 @@ func (t TransferType) strCommand() string {
 	return fmt.Sprintf("TYPE %c", t)
 }
 
-// Name returns the human-readable name of the transfer type.
+// Name returns the human-readable name of the transfer type, or "UNKNOWN" for a
+// value that is neither ASCII nor image/binary (e.g. the zero value).
 func (t TransferType) Name() string {
-	if t.IsAscii() {
+	switch t {
+	case TypeAscii:
 		return "ASCII"
+	case TypeImage:
+		return "BINARY"
+	default:
+		return "UNKNOWN"
 	}
-	return "BINARY"
 }
 
 // IsAscii reports whether the transfer type is ASCII.
@@ -178,7 +183,15 @@ func (s *FTPSession) restoreType(prev TransferType, errp *error) {
 // The original transfer type is restored to the previous value after the transfer
 // (including when the transfer fails at the control level and the session stays
 // open); supports ASCII and binary/Image transfers.
-func (s *FTPSession) StoreIO(remote string, src io.Reader, t TransferType) (sz int64, msg string, err error) {
+func (s *FTPSession) StoreIO(remote string, src io.Reader, t TransferType) (int64, error) {
+	sz, _, err := s.storeIO(remote, src, t)
+	return sz, err
+}
+
+// storeIO is the implementation behind StoreIO that also returns the concatenated
+// server reply text. The public StoreIO drops that text; internal callers (e.g.
+// SubmitIO in jes.go) keep it to parse the JES job id from the submit reply.
+func (s *FTPSession) storeIO(remote string, src io.Reader, t TransferType) (sz int64, msg string, err error) {
 
 	current := s.currentType()
 	if err = s.SetType(t); err != nil {
@@ -202,7 +215,16 @@ func (s *FTPSession) StoreIO(remote string, src io.Reader, t TransferType) (sz i
 // The transfer type is restored to the previous value after the transfer (including
 // when the transfer fails at the control level and the session stays open);
 // supports ASCII and binary/Image transfers.
-func (s *FTPSession) RetrieveIO(remote string, dest io.Writer, t TransferType) (sz int64, msg string, err error) {
+func (s *FTPSession) RetrieveIO(remote string, dest io.Writer, t TransferType) (int64, error) {
+	sz, _, err := s.retrieveIO(remote, dest, t)
+	return sz, err
+}
+
+// retrieveIO is the implementation behind RetrieveIO that also returns the
+// concatenated server reply text. The public RetrieveIO drops that text; internal
+// callers (e.g. SubmitJesGetByDSN in jes.go) keep it to parse the JES job id from
+// the retrieve reply.
+func (s *FTPSession) retrieveIO(remote string, dest io.Writer, t TransferType) (sz int64, msg string, err error) {
 	current := s.currentType()
 	if t.IsAscii() {
 		if err = s.SetStatusOf().SBSendEol(eol.System); err != nil {
@@ -225,15 +247,15 @@ func (s *FTPSession) RetrieveIO(remote string, dest io.Writer, t TransferType) (
 // Resume requires image/binary mode: a positive offset combined with TypeAscii
 // returns ErrAsciiResumeUnsupported before any I/O, because in ASCII mode the
 // server's EOL/codepage translation makes a byte offset corrupt the data.
-func (s *FTPSession) StoreIOAt(remote string, src io.Reader, t TransferType, offset int64) (sz int64, msg string, err error) {
+func (s *FTPSession) StoreIOAt(remote string, src io.Reader, t TransferType, offset int64) (sz int64, err error) {
 
 	if err = guardResume(t, offset); err != nil {
-		return 0, "", err
+		return 0, err
 	}
 
 	current := s.currentType()
 	if err = s.SetType(t); err != nil {
-		return 0, "", err
+		return 0, err
 	}
 	defer s.restoreType(current, &err)
 
@@ -245,8 +267,8 @@ func (s *FTPSession) StoreIOAt(remote string, src io.Reader, t TransferType, off
 		format = transfer.NewStore(src)
 	}
 
-	sz, msg, err = s.transfer(format, remote, offset)
-	return sz, msg, err
+	sz, _, err = s.transfer(format, remote, offset)
+	return sz, err
 }
 
 // RetrieveIOAt performs a retrieve operation starting from the given offset of the remote file.
@@ -256,21 +278,21 @@ func (s *FTPSession) StoreIOAt(remote string, src io.Reader, t TransferType, off
 // Resume requires image/binary mode: a positive offset combined with TypeAscii
 // returns ErrAsciiResumeUnsupported before any I/O, because in ASCII mode the
 // server's EOL/codepage translation makes a byte offset corrupt the data.
-func (s *FTPSession) RetrieveIOAt(remote string, dest io.Writer, t TransferType, offset int64) (sz int64, msg string, err error) {
+func (s *FTPSession) RetrieveIOAt(remote string, dest io.Writer, t TransferType, offset int64) (sz int64, err error) {
 	if err = guardResume(t, offset); err != nil {
-		return 0, "", err
+		return 0, err
 	}
 	current := s.currentType()
 	if t.IsAscii() {
 		if err = s.SetStatusOf().SBSendEol(eol.System); err != nil {
-			return 0, "", err
+			return 0, err
 		}
 	}
 	if err = s.SetType(t); err != nil {
-		return 0, "", err
+		return 0, err
 	}
 	defer s.restoreType(current, &err)
 
-	sz, msg, err = s.transfer(transfer.NewRetrieve(dest), remote, offset)
-	return sz, msg, err
+	sz, _, err = s.transfer(transfer.NewRetrieve(dest), remote, offset)
+	return sz, err
 }

--- a/transfer_mock_test.go
+++ b/transfer_mock_test.go
@@ -19,7 +19,7 @@ func TestRetrieveIO_Binary(t *testing.T) {
 	srv.DataFor("RETR", "MY.BIN", string(want))
 
 	var buf bytes.Buffer
-	n, _, err := s.RetrieveIO("MY.BIN", &buf, zftp.TypeBinary)
+	n, err := s.RetrieveIO("MY.BIN", &buf, zftp.TypeBinary)
 	if err != nil {
 		t.Fatalf("RetrieveIO: %v", err)
 	}
@@ -37,7 +37,7 @@ func TestStoreIO_ASCII_CRLF(t *testing.T) {
 	s, srv := dialMock(t)
 	src := strings.NewReader("alpha\nbeta\ngamma") // LF input, no trailing newline
 
-	n, _, err := s.StoreIO("OUT.TXT", src, zftp.TypeAscii)
+	n, err := s.StoreIO("OUT.TXT", src, zftp.TypeAscii)
 	if err != nil {
 		t.Fatalf("StoreIO: %v", err)
 	}
@@ -60,7 +60,7 @@ func TestStoreIO_ASCII_CRLF(t *testing.T) {
 // store's TYPE A.
 func TestStoreIO_RestoresType(t *testing.T) {
 	s, srv := dialMock(t)
-	if _, _, err := s.StoreIO("F", strings.NewReader("x"), zftp.TypeAscii); err != nil {
+	if _, err := s.StoreIO("F", strings.NewReader("x"), zftp.TypeAscii); err != nil {
 		t.Fatalf("StoreIO: %v", err)
 	}
 
@@ -88,7 +88,7 @@ func TestRetrieveIOAt_Offset(t *testing.T) {
 	srv.DataFor("RETR", "BIG.SEQ", "tail-bytes")
 
 	var buf bytes.Buffer
-	if _, _, err := s.RetrieveIOAt("BIG.SEQ", &buf, zftp.TypeBinary, 4096); err != nil {
+	if _, err := s.RetrieveIOAt("BIG.SEQ", &buf, zftp.TypeBinary, 4096); err != nil {
 		t.Fatalf("RetrieveIOAt: %v", err)
 	}
 	if !hasCmd(srv.Commands(), "REST 4096") {
@@ -110,7 +110,7 @@ func TestRetrieveIOAt_AsciiOffsetRejected(t *testing.T) {
 
 	before := len(srv.Commands())
 	var buf bytes.Buffer
-	_, _, err := s.RetrieveIOAt("BIG.SEQ", &buf, zftp.TypeAscii, 100)
+	_, err := s.RetrieveIOAt("BIG.SEQ", &buf, zftp.TypeAscii, 100)
 	if !errors.Is(err, zftp.ErrAsciiResumeUnsupported) {
 		t.Fatalf("err = %v, want ErrAsciiResumeUnsupported", err)
 	}
@@ -129,7 +129,7 @@ func TestStoreIOAt_AsciiOffsetRejected(t *testing.T) {
 	s, srv := dialMock(t)
 
 	before := len(srv.Commands())
-	_, _, err := s.StoreIOAt("OUT.TXT", strings.NewReader("alpha\nbeta\n"), zftp.TypeAscii, 100)
+	_, err := s.StoreIOAt("OUT.TXT", strings.NewReader("alpha\nbeta\n"), zftp.TypeAscii, 100)
 	if !errors.Is(err, zftp.ErrAsciiResumeUnsupported) {
 		t.Fatalf("err = %v, want ErrAsciiResumeUnsupported", err)
 	}
@@ -152,7 +152,7 @@ func TestRetrieveIO_RestoresTypeOnControlFailure(t *testing.T) {
 	srv.Script("RETR", "550 not found")
 
 	var buf bytes.Buffer
-	_, _, err := s.RetrieveIO("NO.SUCH.FILE", &buf, zftp.TypeAscii)
+	_, err := s.RetrieveIO("NO.SUCH.FILE", &buf, zftp.TypeAscii)
 	if err == nil {
 		t.Fatal("expected an error from the rejected RETR")
 	}
@@ -174,7 +174,7 @@ func TestStoreIO_RestoresTypeOnControlFailure(t *testing.T) {
 	s, srv := dialMock(t)
 	srv.Script("STOR", "550 access denied")
 
-	_, _, err := s.StoreIO("NO.SUCH.FILE", strings.NewReader("data"), zftp.TypeAscii)
+	_, err := s.StoreIO("NO.SUCH.FILE", strings.NewReader("data"), zftp.TypeAscii)
 	if err == nil {
 		t.Fatal("expected an error from the rejected STOR")
 	}
@@ -197,7 +197,7 @@ func TestRetrieveIO_RestoresTypeOnSuccess(t *testing.T) {
 	srv.DataFor("RETR", "MY.TXT", "hello\r\n")
 
 	var buf bytes.Buffer
-	if _, _, err := s.RetrieveIO("MY.TXT", &buf, zftp.TypeAscii); err != nil {
+	if _, err := s.RetrieveIO("MY.TXT", &buf, zftp.TypeAscii); err != nil {
 		t.Fatalf("RetrieveIO: %v", err)
 	}
 
@@ -217,7 +217,7 @@ func TestStoreIOAt_BinaryOffset(t *testing.T) {
 	s, srv := dialMock(t)
 	payload := []byte{0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x10}
 
-	n, _, err := s.StoreIOAt("BIG.BIN", bytes.NewReader(payload), zftp.TypeBinary, 2048)
+	n, err := s.StoreIOAt("BIG.BIN", bytes.NewReader(payload), zftp.TypeBinary, 2048)
 	if err != nil {
 		t.Fatalf("StoreIOAt: %v", err)
 	}

--- a/v2_hardening_test.go
+++ b/v2_hardening_test.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package zftp_test
+
+import (
+	"bytes"
+	"errors"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	zftp "gopkg.in/ro-ag/zftp.v2"
+	"gopkg.in/ro-ag/zftp.v2/internal/mockzos"
+)
+
+// M1: a session that has never had its transfer type set (e.g. used before
+// Login) must not restore to the zero TransferType, which would send the invalid
+// "TYPE \x00". The connect-time default is ASCII (RFC 959 §3.1.1.3).
+func TestTransfer_FreshSessionNeverSendsNullType(t *testing.T) {
+	srv := mockzos.New(t)
+	s, err := zftp.Open(srv.Addr()) // deliberately NO Login: currType stays unset
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	srv.DataFor("RETR", "FOO", "hello")
+	var buf bytes.Buffer
+	if _, err := s.RetrieveIO("FOO", &buf, zftp.TypeImage); err != nil {
+		t.Fatalf("RetrieveIO on fresh session: %v", err)
+	}
+	for _, c := range srv.Commands() {
+		if strings.ContainsRune(c, 0) {
+			t.Fatalf("a TYPE command carried a NUL byte (currType zero value): %q", c)
+		}
+	}
+}
+
+// M2: a control reply that never arrives must not hang the caller forever. The
+// data command (RETR/STOR) and REST are issued via SendCommand; every SendCommand
+// round-trip must be bounded by the reply timeout.
+func TestTransfer_StalledCommandReplyTimesOut(t *testing.T) {
+	srv := mockzos.New(t)
+	s, err := zftp.Open(srv.Addr(), zftp.WithReplyTimeout(300*time.Millisecond))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	if err := s.Login("ME", "PW"); err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+
+	srv.Withhold("RETR") // server consumes RETR but never sends a reply
+
+	done := make(chan error, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, e := s.RetrieveIO("FOO", &buf, zftp.TypeImage)
+		done <- e
+	}()
+	select {
+	case e := <-done:
+		if e == nil {
+			t.Fatal("expected a timeout error from the withheld RETR reply, got nil")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("RetrieveIO hung on a withheld RETR reply: control read has no deadline")
+	}
+}
+
+// M5: checkLast (and the exported CheckLast) must never report success on a
+// closed session. Returning ("", nil) would let confirmData report a transfer
+// whose terminal reply was never read as complete.
+func TestCheckLast_ClosedSessionReturnsError(t *testing.T) {
+	s, _ := dialMock(t)
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	_, err := s.CheckLast(zftp.CodeFileActionOK)
+	if err == nil {
+		t.Fatal("CheckLast on a closed session returned nil (false success)")
+	}
+	if !errors.Is(err, net.ErrClosed) {
+		t.Fatalf("want net.ErrClosed, got %v", err)
+	}
+}
+
+// M7: a passive transfer whose terminal control reply is not a completion code
+// (e.g. 426 "transfer aborted", which z/OS may follow with a second reply such as
+// 226) must close the session. FTP has no in-band control-stream resync, so a
+// trailing reply left buffered would desync the next command ("shifted messages").
+func TestTransfer_AbortCompletionReplyClosesSession(t *testing.T) {
+	s, srv := dialMock(t)
+	srv.DataFor("RETR", "FOO", "hello")
+	srv.CompletionReply("RETR", "426 connection closed; transfer aborted")
+
+	var buf bytes.Buffer
+	_, err := s.RetrieveIO("FOO", &buf, zftp.TypeImage)
+	if err == nil {
+		t.Fatal("expected an error from the 426 abort completion, got nil")
+	}
+	if !s.IsClosed() {
+		t.Fatal("session left open after a non-completion (426) transfer reply: a trailing reply will desync the next command")
+	}
+}
+
+// Minor: a failed login must not leave the attempted username recorded; User
+// should reflect only a successful authentication.
+func TestLogin_FailedLoginDoesNotRecordUser(t *testing.T) {
+	srv := mockzos.New(t)
+	s, err := zftp.Open(srv.Addr())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	srv.Script("PASS", "530 not logged in")
+	if err := s.Login("ME", "BADPW"); err == nil {
+		t.Fatal("expected a login failure")
+	}
+	if u := s.User(); u != "" {
+		t.Fatalf("User() = %q after a failed login, want empty", u)
+	}
+}

--- a/whitebox_minors_test.go
+++ b/whitebox_minors_test.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package zftp
+
+import (
+	"testing"
+
+	"gopkg.in/ro-ag/zftp.v2/internal/log"
+)
+
+// An argument-less command must not carry a trailing space (RFC 959 command
+// lines are "verb CRLF" with no arguments, e.g. "NOOP\r\n" not "NOOP \r\n").
+func TestParseCommand_NoTrailingSpaceWhenArgless(t *testing.T) {
+	lg := log.New(nil, log.None)
+	if got := string(parseCommand(lg, "NOOP")); got != "NOOP\r\n" {
+		t.Fatalf("argless command = %q, want %q", got, "NOOP\r\n")
+	}
+}
+
+func TestParseCommand_WithArgsUnchanged(t *testing.T) {
+	lg := log.New(nil, log.None)
+	if got := string(parseCommand(lg, "RETR", "FOO")); got != "RETR FOO\r\n" {
+		t.Fatalf("command with args = %q, want %q", got, "RETR FOO\r\n")
+	}
+}
+
+// Name must not label an unknown/zero TransferType as "BINARY".
+func TestTransferType_NameUnknownForZeroValue(t *testing.T) {
+	if got := TransferType(0).Name(); got != "UNKNOWN" {
+		t.Fatalf("TransferType(0).Name() = %q, want UNKNOWN", got)
+	}
+	if got := TypeAscii.Name(); got != "ASCII" {
+		t.Fatalf("TypeAscii.Name() = %q, want ASCII", got)
+	}
+	if got := TypeImage.Name(); got != "BINARY" {
+		t.Fatalf("TypeImage.Name() = %q, want BINARY", got)
+	}
+}


### PR DESCRIPTION
v2.0.0 release-gate hardening from a deep code review. All changes are TDD; full gate green under -race on both modules (gofmt/build/vet/staticcheck/govulncheck + cli). Review record in docs/v2-readiness-review.md.

## Correctness (review findings)
- **currType default** — newSession seeds TypeAscii so a pre-Login transfer never restores to the zero TransferType ("TYPE \x00").
- **Bounded control reads** — every SendCommand round-trip is now bounded by the reply timeout; an accepted command whose reply never arrives no longer hangs the caller.
- **Bounded data-connection TLS handshake** — a stalled FTPS negotiation can no longer hang a transfer.
- **Multiline reply EOF** — codes.check returns io.ErrUnexpectedEOF on EOF before the terminator line; a truncated reply is no longer reported as success.
- **checkLast on closed session** — returns net.ErrClosed (no false completion).
- **Passive-abort desync** — checkLast closes the session on a non-completion (426) post-transfer reply, preventing the trailing-reply "shift".
- **JES docs** — corrected the ABAxxx="abend" docs (ABAxxx are DFSMShsm ABARS messages); a spool-scan abend matcher is parked pending a real $HASP395 ABEND capture.

## v2 API polish (breaking, pre-tag)
- hfs Field*/Info* String/Value/MarshalJSON use value receivers, so returned values satisfy fmt.Stringer/json.Marshaler (fixes single-value json.Marshal emitting {}, e.g. `zftp job --json`).
- jobDetail exported as JobDetail (Detail() returns a nameable type).
- *IO methods return (int64, error); the raw reply text is kept on unexported helpers for JES job-id parsing.
- RECFM consts WithRecfm* -> Recfm*; GetUser() -> User().
- Doc-coverage gate extended to hfs/eol; ~48 idents documented.
- Compile-time interface assertions (var _ Iface = Type{}) across the returned/concrete types and the cli client boundary.

## Minors
Dead utils removed; no trailing space on argument-less commands; login user recorded only after PASS; TransferType.Name -> "UNKNOWN" for unknown values; signal-handler and SubmitJesGetByDSN SITE-clobber documented.

## Parked (need real z/OS captures or a decision)
- JES spool abend matcher — needs a real $HASP395 ABEND sample.
- ServerStatus.Snapshot() — needs real STAT captures.
- StatusOf/SetStatusOf rename — left as-is (38+ sites, debatable gain).